### PR TITLE
Fix Ralph token mount path in devcontainer setup

### DIFF
--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -113,6 +113,7 @@ export function writeDevContainer(config, templateName, setupGitHub = false, _to
     finalConfig.mounts = [
       ...(finalConfig.mounts || []),
       { source: `gh-config-${slug}`, target: '/home/vscode/.config/gh', type: 'volume' },
+      { source: '${localWorkspaceFolder}/.ralph/token', target: '/tmp/ralph_token', type: 'bind', readonly: true },
     ];
 
     const existingCommand = finalConfig.postCreateCommand || '';
@@ -124,7 +125,7 @@ export function writeDevContainer(config, templateName, setupGitHub = false, _to
     finalConfig.postStartCommand =
       'unset VSCODE_GIT_IPC_HANDLE GIT_ASKPASS VSCODE_GIT_ASKPASS_NODE VSCODE_GIT_ASKPASS_MAIN' +
       ' && git config --global --unset-all credential.helper || true' +
-      ' && gh auth login --with-token < ${containerWorkspaceFolder}/.ralph/token && gh auth setup-git';
+      ' && gh auth login --with-token < /tmp/ralph_token && gh auth setup-git';
   } else {
     finalConfig.postCreateCommand = finalConfig.postCreateCommand || '';
   }


### PR DESCRIPTION
## Summary
Updated the devcontainer configuration to properly mount the Ralph authentication token file using a bind mount instead of relying on a container-relative path.

## Key Changes
- Added a new bind mount that maps the local `.ralph/token` file to `/tmp/ralph_token` inside the container with read-only access
- Updated the `postStartCommand` to read the token from the new mount path (`/tmp/ralph_token`) instead of the previous container workspace folder path (`${containerWorkspaceFolder}/.ralph/token`)

## Implementation Details
The change ensures that the Ralph token is properly accessible within the devcontainer by:
1. Explicitly binding the host's `.ralph/token` file to a fixed path in the container (`/tmp/ralph_token`)
2. Using the absolute container path in the authentication command rather than a relative workspace path, which improves reliability across different workspace configurations
3. Setting the mount as read-only to prevent accidental modifications to the token file from within the container

https://claude.ai/code/session_01VYxaYWyGpzwe4Fx3QxZxB2