### PR TITLE
fix: grant write permissions to GitHub Actions for PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Changed `pull-requests` and `issues` permissions from `read` to `write` in both `claude.yml` and `claude-code-review.yml`

## Why
Claude Code action was unable to post review comments on PRs because it lacked write access to the pull-requests and issues APIs (GitHub PR comments use the issues API internally).

## Test plan
- [ ] Open a new PR and verify `claude-code-review` workflow runs and posts a review comment automatically
- [ ] Verify `@claude` mentions in PR comments still work and Claude can respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)