### PR TITLE
Pin RTK install script to specific commit hash

### DIFF
--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -13,7 +13,8 @@ import path from 'path';
  * RTK install script (universal Linux/macOS). Idempotent — re-running
  * upgrades RTK in place.
  */
-const RTK_INSTALL = 'curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh';
+// Pinned to v0.37.2 (80a6fe606f73b19e52b0b330d242e62a6c07be42) to prevent supply-chain risk from a mutable branch ref.
+const RTK_INSTALL = 'curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/80a6fe606f73b19e52b0b330d242e62a6c07be42/install.sh | sh';
 
 /**
  * Per-CLI `rtk init` invocation. RTK is universal but the init flag


### PR DESCRIPTION
## Summary
Updated the RTK installation script URL to use a pinned commit hash instead of the mutable `master` branch reference, reducing supply-chain risk.

## Changes
- Changed RTK install URL from `refs/heads/master` to a specific commit hash (`80a6fe606f73b19e52b0b330d242e62a6c07be42`)
- Added explanatory comment documenting the pin to v0.37.2 and the rationale for using an immutable commit reference

## Details
This change prevents unexpected behavior from automatic updates to the RTK installation script. By pinning to a specific commit hash rather than relying on the mutable `master` branch, we ensure consistent and reproducible installations across all devcontainer setups. The pinned commit corresponds to RTK v0.37.2.

https://claude.ai/code/session_0124vNw1jgBq1ebQWNU9NmcV