### PR TITLE
Refactor CLI flow: decouple GitHub setup from devcontainer

### DIFF
--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -27,19 +27,21 @@ const RTK_INIT_BY_CLI = {
 };
 
 /**
- * Caveman install command (Claude Code only). The plugin marketplace
- * install works without claude auth at container-create time.
+ * Caveman install command (Claude Code only). Guarded so the plugin
+ * marketplace registration and install are skipped when the `.claude`
+ * volume already contains the plugin from a prior build.
  */
 const CAVEMAN_INSTALL_CLAUDE =
-  'claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman';
+  '[ -d /home/vscode/.claude/plugins/caveman ] || (claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman)';
 
 /**
  * Shallow-clones the VoltAgent awesome-claude-code-subagents list into
- * the project-scoped `.claude/agents` volume. Claude Code discovers
- * agents there automatically.
+ * the project-scoped `.claude/agents` volume. Guarded so a second
+ * container build doesn't re-clone into an already-populated directory
+ * and break the `&&` chain.
  */
 const SUBAGENTS_CLONE =
-  'mkdir -p /home/vscode/.claude/agents && git clone --depth=1 https://github.com/VoltAgent/awesome-claude-code-subagents /home/vscode/.claude/agents/awesome-subagents';
+  '[ -d /home/vscode/.claude/agents/awesome-subagents ] || (mkdir -p /home/vscode/.claude/agents && git clone --depth=1 https://github.com/VoltAgent/awesome-claude-code-subagents /home/vscode/.claude/agents/awesome-subagents)';
 
 /**
  * VS Code settings that prevent the host's git credentials from being


### PR DESCRIPTION
## Summary
This PR restructures the Ralph CLI initialization flow to decouple GitHub repository setup from Dev Container configuration. The main CLI now orchestrates the sequence of prompts and operations, allowing users to set up GitHub isolation independently of whether they choose container isolation. Additionally, Claude-specific tool installations (Caveman plugin and awesome-subagents collection) are now prompted and integrated into the devcontainer setup.

## Key Changes

- **Refactored `cli.js` orchestration**: Moved template selection and GitHub setup logic into the main CLI flow. The CLI now:
  - Prompts for isolation preference, GitHub setup, and Claude-specific tools in sequence
  - Closes readline before template selection (which requires raw keypress mode)
  - Delegates to `setupGitHubAccess()` and `writeDevContainer()` based on user choices
  - Supports GitHub setup independently of container isolation

- **Simplified `devcontainer.js`**: Renamed `setupDevContainer()` to `selectTemplate()` and removed nested GitHub/devcontainer logic. The function now only presents the template menu and returns the selection.

- **Enhanced `github-access.js`**: 
  - Removed devcontainer writing responsibility (now handled by caller)
  - Made `_getGitHubUsername()` and `_createGitHubRepo()` async with retry loops
  - Improved error messages and user feedback for authentication/repo creation failures
  - Added note about private repository creation using gh CLI

- **Extended `write-devcontainer.js`**:
  - Added RTK (RTK AI) installation and initialization to all devcontainers
  - Introduced per-CLI RTK init flags (claude, codex, gemini, opencode)
  - Added optional Caveman plugin installation (Claude-only)
  - Added optional awesome-claude-code-subagents collection cloning (Claude-only)
  - Refactored postCreateCommand building to compose commands from reusable constants
  - Added token bind mount for GitHub PAT isolation

- **Updated `scaffold.js`**: 
  - Made `scaffoldRalph()` async
  - Added prompt to warn and confirm when `scripts/` directory already exists
  - Improved error handling for file copy operations

- **Enhanced test coverage** (`write-devcontainer.test.js` and `scaffold.test.js`):
  - Added tests for RTK installation and per-CLI init flags
  - Added tests for Caveman and subagents installation (Claude-only guards)
  - Added tests for scaffold overwrite confirmation flow
  - Moved test directory to system temp directory for better isolation

- **Updated GitHub Actions workflows**: Elevated `pull-requests` and `issues` permissions from `read` to `write` to support Claude's code review and issue commenting capabilities.

- **Version bump**: Updated to v2.0.4

## Notable Implementation Details

- RTK installation and initialization are now universal across all devcontainers, with CLI-specific init flags selected via lookup table
- Caveman and subagents features are guarded to only prompt and install for Claude CLI, keeping the flow concise for other CLIs
- GitHub credential helper cleanup is now part of the composed postCreateCommand chain rather than conditional logic
- The scaffold function now provides user-friendly warnings and confirmation before overwriting existing script directories

https://claude.ai/code/session_01E6hxou8ckxDJAV14rnPTRX