### PR TITLE
release: v2.0.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
+      - 'release/**'
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## When a test is failing
+
+Before changing implementation code, check `git log`/`git blame` to understand why it was written that way. Fix the test to match the implementation unless the implementation is clearly wrong.

--- a/__tests__/scaffold.test.js
+++ b/__tests__/scaffold.test.js
@@ -3,9 +3,17 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-vi.mock('../bin/lib/ui.js', () => ({ ask: vi.fn(), rl: { close: vi.fn() } }));
+const mockQuestion = vi.fn();
+const mockClose = vi.fn();
+vi.mock('readline', () => ({
+  default: {
+    createInterface: vi.fn(() => ({
+      question: mockQuestion,
+      close: mockClose,
+    })),
+  },
+}));
 
-import { ask } from '../bin/lib/ui.js';
 import { scaffoldRalph } from '../bin/commands/scaffold.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -18,6 +26,7 @@ const TEST_DIR = path.join(os.tmpdir(), '.test-scaffold-vitest');
 describe('scaffoldRalph', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockQuestion.mockImplementation((_prompt, cb) => cb('y'));
     if (fs.existsSync(TEST_DIR)) {
       fs.rmSync(TEST_DIR, { recursive: true });
     }
@@ -91,14 +100,14 @@ describe('scaffoldRalph', () => {
   });
 
   it('should warn and prompt when scripts/ already exists, then overwrite on confirm', async () => {
-    ask.mockResolvedValue('y');
+    mockQuestion.mockImplementation((_prompt, cb) => cb('y'));
     const originalCwd = process.cwd();
     try {
       process.chdir(TEST_DIR);
       fs.mkdirSync(path.join(TEST_DIR, 'scripts'), { recursive: true });
       await scaffoldRalph('claude');
 
-      expect(ask).toHaveBeenCalledWith(expect.stringContaining('Proceed and overwrite?'));
+      expect(mockQuestion).toHaveBeenCalledWith(expect.stringContaining('Proceed and overwrite?'), expect.any(Function));
       expect(fs.existsSync(path.join(TEST_DIR, 'scripts', 'ralph', 'ralph.sh'))).toBe(true);
     } finally {
       process.chdir(originalCwd);
@@ -106,7 +115,7 @@ describe('scaffoldRalph', () => {
   });
 
   it('should abort scaffold when user declines overwrite prompt', async () => {
-    ask.mockResolvedValue('n');
+    mockQuestion.mockImplementation((_prompt, cb) => cb('n'));
     const originalCwd = process.cwd();
     try {
       process.chdir(TEST_DIR);

--- a/__tests__/write-devcontainer.test.js
+++ b/__tests__/write-devcontainer.test.js
@@ -76,12 +76,6 @@ describe('writeDevContainer', () => {
       expect(ghMount).toBeDefined();
       expect(ghMount.target).toBe('/home/vscode/.config/gh');
       expect(ghMount.type).toBe('volume');
-
-      const tokenMount = config.mounts?.find(m => m.target === '/tmp/ralph_token');
-      expect(tokenMount).toBeDefined();
-      expect(tokenMount.source).toBe('${localWorkspaceFolder}/.ralph/token');
-      expect(tokenMount.type).toBe('bind');
-      expect(tokenMount.readonly).toBe(true);
     } finally {
       process.chdir(originalCwd);
     }

--- a/__tests__/write-devcontainer.test.js
+++ b/__tests__/write-devcontainer.test.js
@@ -114,4 +114,79 @@ describe('writeDevContainer', () => {
       process.chdir(originalCwd);
     }
   });
+
+  it('always installs RTK and runs the claude-flavored init for claude', () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude');
+      const config = readGenerated();
+      expect(config.postCreateCommand).toContain('rtk-ai/rtk');
+      expect(config.postCreateCommand).toMatch(/rtk init -g(?!\s--)/);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('uses the per-CLI rtk init flag for non-claude CLIs', () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'gemini');
+      const config = readGenerated();
+      expect(config.postCreateCommand).toContain('rtk init -g --gemini');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('appends caveman install only when opted in and cliName is claude', () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude', { caveman: true });
+      expect(readGenerated().postCreateCommand).toContain('claude plugin install caveman@caveman');
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude');
+      expect(readGenerated().postCreateCommand).not.toContain('caveman');
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'gemini', { caveman: true });
+      expect(readGenerated().postCreateCommand).not.toContain('caveman');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('appends subagents clone only when opted in and cliName is claude', () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude', { subagents: true });
+      expect(readGenerated().postCreateCommand).toContain('awesome-claude-code-subagents');
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude');
+      expect(readGenerated().postCreateCommand).not.toContain('awesome-claude-code-subagents');
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'gemini', { subagents: true });
+      expect(readGenerated().postCreateCommand).not.toContain('awesome-claude-code-subagents');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('still appends credential.helper cleanup when GitHub is enabled alongside new tools', () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+      writeDevContainer(BASE_CONFIG, 'Node.js', true, null, false, 'claude', { caveman: true });
+      const cmd = readGenerated().postCreateCommand;
+      expect(cmd).toContain('rtk init -g');
+      expect(cmd).toContain('credential.helper');
+      expect(cmd).toContain('caveman');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
 });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -95,6 +95,18 @@ async function main() {
   const githubAnswer = await ask('Set up GitHub repository with isolated PAT token? [Y/n]: ');
   const wantsGitHub = githubAnswer.trim().toLowerCase() !== 'n';
 
+  // Caveman and the awesome-subagents list are Claude-specific — skip their
+  // prompts for other CLIs so the flow stays short.
+  let wantsCaveman = false;
+  let wantsSubagents = false;
+  if (cliName === 'claude') {
+    const cavemanAnswer = await ask('Install Caveman debugging plugin? [y/N]: ');
+    wantsCaveman = cavemanAnswer.trim().toLowerCase() === 'y';
+
+    const subagentsAnswer = await ask('Install curated awesome-claude-code-subagents collection? [y/N]: ');
+    wantsSubagents = subagentsAnswer.trim().toLowerCase() === 'y';
+  }
+
   // Template selection uses raw keypress mode and closes rl — must come after all ask() calls.
   let template = null;
   if (wantsIsolation) {
@@ -103,15 +115,17 @@ async function main() {
     rl.close();
   }
 
+  const tools = { caveman: wantsCaveman, subagents: wantsSubagents };
+
   if (!wantsIsolation && !wantsGitHub) {
     console.log('\n  ⚠️  Proceeding without isolation. Be careful.\n');
   } else if (wantsGitHub) {
     await setupGitHubAccess();
     if (wantsIsolation) {
-      writeDevContainer(template.config, template.name, true, null, DEBUG, cliName);
+      writeDevContainer(template.config, template.name, true, null, DEBUG, cliName, tools);
     }
   } else {
-    writeDevContainer(template.config, template.name, false, null, DEBUG, cliName);
+    writeDevContainer(template.config, template.name, false, null, DEBUG, cliName, tools);
   }
 
   await scaffoldRalph(cliName);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,14 +11,16 @@
  *   1. Print the current package version.
  *   2. Ask which AI coding CLI to use.
  *   3. Ask whether to set up a VS Code Dev Container for isolation.
- *   4a. Yes → pick a container template → optionally set up a scoped GitHub PAT.
- *   4b. No  → confirm the user understands the risk, then proceed directly.
- *   5. Copy Ralph template files and generate ralph.sh for the chosen CLI.
+ *   4. Ask whether to set up a scoped GitHub PAT (independent of step 3).
+ *   5. If isolation: pick a container template (closes readline).
+ *   6. Execute the chosen combination, then scaffold Ralph files.
  */
 
 import { createRequire } from 'module';
 import { rl, ask } from './lib/ui.js';
-import { setupDevContainer } from './commands/devcontainer.js';
+import { selectTemplate } from './commands/devcontainer.js';
+import { setupGitHubAccess } from './commands/github-access.js';
+import { writeDevContainer } from './lib/write-devcontainer.js';
 import { scaffoldRalph } from './commands/scaffold.js';
 import CLI_MAP from './lib/cli-map.js';
 
@@ -90,15 +92,29 @@ async function main() {
   const isolateAnswer = await ask('Set up VS Code Dev Container for isolation? [Y/n]: ');
   const wantsIsolation = isolateAnswer.trim().toLowerCase() !== 'n';
 
-  if (!wantsIsolation) {
-    console.log('\n  ⚠️  Proceeding without isolation. Be careful.\n');
-    await scaffoldRalph(cliName);
-    rl.close();
+  const githubAnswer = await ask('Set up GitHub repository with isolated PAT token? [Y/n]: ');
+  const wantsGitHub = githubAnswer.trim().toLowerCase() !== 'n';
+
+  // Template selection uses raw keypress mode and closes rl — must come after all ask() calls.
+  let template = null;
+  if (wantsIsolation) {
+    template = await selectTemplate();
   } else {
-    await setupDevContainer(DEBUG, cliName);
-    // Note: rl was already closed inside selectMenu
-    await scaffoldRalph(cliName);
+    rl.close();
   }
+
+  if (!wantsIsolation && !wantsGitHub) {
+    console.log('\n  ⚠️  Proceeding without isolation. Be careful.\n');
+  } else if (wantsGitHub) {
+    await setupGitHubAccess();
+    if (wantsIsolation) {
+      writeDevContainer(template.config, template.name, true, null, DEBUG, cliName);
+    }
+  } else {
+    writeDevContainer(template.config, template.name, false, null, DEBUG, cliName);
+  }
+
+  await scaffoldRalph(cliName);
 }
 
 main();

--- a/bin/commands/devcontainer.js
+++ b/bin/commands/devcontainer.js
@@ -1,38 +1,20 @@
 /**
  * Dev Container setup command.
  *
- * Presents the template selection menu, asks whether to configure GitHub
- * isolation, then delegates to the appropriate sub-command.
+ * Presents the template selection menu and returns the chosen template.
+ * Orchestration (GitHub setup, writeDevContainer) is handled by cli.js.
  */
 
-import readline from 'readline';
 import { selectMenu } from '../lib/ui.js';
 import { TEMPLATES } from '../lib/devcontainer-templates.js';
-import { writeDevContainer } from '../lib/write-devcontainer.js';
-import { setupGitHubAccess } from './github-access.js';
 
 /**
- * Run the interactive Dev Container setup flow.
- * @param {boolean} debug - If true, isolation-check scripts are injected.
+ * Show the interactive template menu and return the selected template.
+ * Note: selectMenu closes the shared readline interface.
+ * @returns {Promise<object>} The chosen template object.
  */
-export async function setupDevContainer(debug = false, cliName = 'claude') {
+export async function selectTemplate() {
   console.log('\nSelect a Dev Container template (use arrow keys, Enter to confirm):\n');
-
   const idx = await selectMenu(TEMPLATES.map(t => t.label));
-  const template = TEMPLATES[idx];
-
-  // Recreate readline after selectMenu closed it
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  const githubAnswer = await new Promise(resolve =>
-    rl.question('\nSet up GitHub repository with isolated PAT token? [Y/n]: ', resolve)
-  );
-  rl.close();
-
-  const wantsGitHub = githubAnswer.trim().toLowerCase() !== 'n';
-
-  if (wantsGitHub) {
-    await setupGitHubAccess(template.config, template.name, debug, cliName);
-  } else {
-    writeDevContainer(template.config, template.name, false, null, debug, cliName);
-  }
+  return TEMPLATES[idx];
 }

--- a/bin/commands/github-access.js
+++ b/bin/commands/github-access.js
@@ -28,16 +28,14 @@ export async function setupGitHubAccess(config, templateName, debug = false, cli
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   const ask = (q) => new Promise(resolve => rl.question(q, resolve));
 
-  /** // FIXME: if failed, give option for user to retry
-   give notes that github creation is using specific script to create **/
   console.log(`\nSetting up GitHub isolation for project: ${projectName}`);
-  
 
   _ensureGitRepo();
 
   const userName = _getGitHubUsername();
 
-  _createGitHubRepo(projectName, userName);
+  console.log('Note: a private GitHub repository will be created automatically using the gh CLI.');
+  await _createGitHubRepo(projectName, userName, ask);
 
   const token = await _promptForPAT(ask, projectName, userName);
   rl.close();
@@ -73,18 +71,36 @@ function _getGitHubUsername() {
 
 /**
  * Create a private GitHub repo for the current project and ensure a remote is set.
- * @param {string} projectName
- * @param {string} userName
+ * Retries on failure until the user succeeds or declines.
+ * @param {string}   projectName
+ * @param {string}   userName
+ * @param {function} ask
  */
-function _createGitHubRepo(projectName, userName) {
+async function _createGitHubRepo(projectName, userName, ask) {
   console.log('Creating private GitHub repository...');
-  try {
-    execSync(
-      `gh repo create "${projectName}" --private --source=. --push 2>/dev/null || gh repo create "${projectName}" --private`,
-      { stdio: 'inherit' }
-    );
-  } catch {
-    console.error('Warning: Could not create repo. It may already exist.');
+  while (true) {
+    try {
+      execSync(
+        `gh repo create "${projectName}" --private --source=. --push`,
+        { stdio: 'pipe' }
+      );
+      break;
+    } catch (err) {
+      const stderr = (err.stderr || '').toString();
+      if (stderr.toLowerCase().includes('already exists')) {
+        console.log('Repository already exists, continuing...');
+        break;
+      }
+      console.error(`\nFailed to create GitHub repository: ${stderr.trim() || 'unknown error'}`);
+      const answer = await ask('Would you like to retry? (y/n): ');
+      if (answer.trim().toLowerCase() !== 'y') {
+        console.error('\nCannot continue without a GitHub repository. Before re-running, check:');
+        console.error('  • gh auth status  — ensure you are authenticated');
+        console.error('  • The repository name is not already taken under a different account');
+        console.error('  • You have permission to create repositories on this account');
+        process.exit(1);
+      }
+    }
   }
 
   try {

--- a/bin/commands/github-access.js
+++ b/bin/commands/github-access.js
@@ -32,7 +32,7 @@ export async function setupGitHubAccess(config, templateName, debug = false, cli
 
   _ensureGitRepo();
 
-  const userName = _getGitHubUsername();
+  const userName = await _getGitHubUsername(ask);
 
   console.log('Note: a private GitHub repository will be created automatically using the gh CLI.');
   await _createGitHubRepo(projectName, userName, ask);
@@ -57,15 +57,24 @@ function _ensureGitRepo() {
 
 /**
  * Resolve the authenticated GitHub username via the gh CLI.
- * Exits with an error if gh is not authenticated.
- * @returns {string}
+ * Retries on failure until the user succeeds or declines.
+ * @param {function} ask
+ * @returns {Promise<string>}
  */
-function _getGitHubUsername() {
-  try {
-    return execSync('gh api user -q .login', { encoding: 'utf8' }).trim();
-  } catch {
-    console.error('Error: gh CLI not authenticated. Please run: gh auth login');
-    process.exit(1);
+async function _getGitHubUsername(ask) {
+  while (true) {
+    try {
+      return execSync('gh api user -q .login', { encoding: 'utf8', stdio: 'pipe' }).trim();
+    } catch (err) {
+      const stderr = (err.stderr || '').toString().trim();
+      console.error(`\nFailed to reach GitHub: ${stderr || 'unknown error'}`);
+      console.error('Ensure gh is authenticated (gh auth login) and you have internet access.');
+      const answer = await ask('Would you like to retry? (y/n): ');
+      if (answer.trim().toLowerCase() !== 'y') {
+        console.error('\nCannot continue without GitHub access. Run `gh auth login` and try again.');
+        process.exit(1);
+      }
+    }
   }
 }
 

--- a/bin/commands/github-access.js
+++ b/bin/commands/github-access.js
@@ -15,15 +15,12 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
 import { execSync } from 'child_process';
-import { writeDevContainer } from '../lib/write-devcontainer.js';
 
 /**
- * Full GitHub isolation setup flow.
- * @param {object}  config       - Base devcontainer config from the selected template.
- * @param {string}  templateName - Human-readable template name.
- * @param {boolean} debug        - Whether to inject isolation-check scripts.
+ * Git repository, GitHub repo creation, and PAT token setup flow.
+ * Devcontainer writing is handled by the caller.
  */
-export async function setupGitHubAccess(config, templateName, debug = false, cliName = 'claude') {
+export async function setupGitHubAccess() {
   const projectName = path.basename(process.cwd());
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   const ask = (q) => new Promise(resolve => rl.question(q, resolve));
@@ -41,8 +38,6 @@ export async function setupGitHubAccess(config, templateName, debug = false, cli
   rl.close();
 
   _storeToken(token);
-
-  writeDevContainer(config, templateName, true, null, debug, cliName);
 }
 
 /** Initialise a git repo in cwd if one does not already exist. */

--- a/bin/commands/scaffold.js
+++ b/bin/commands/scaffold.js
@@ -9,8 +9,8 @@
 
 import fs from 'fs';
 import path from 'path';
+import readline from 'readline';
 import { fileURLToPath } from 'url';
-import { ask } from '../lib/ui.js';
 import { writeRalphSh } from '../lib/generate-ralph-sh.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -32,7 +32,9 @@ export async function scaffoldRalph(cliName = 'claude') {
   if (existingDirs.length > 0) {
     console.warn('\nWarning: the following director' + (existingDirs.length > 1 ? 'ies' : 'y') + ' already exist and will be overwritten:');
     existingDirs.forEach(d => console.warn('  ' + d));
-    const answer = await ask('\nProceed and overwrite? [y/N]: ');
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise(resolve => rl.question('\nProceed and overwrite? [y/N]: ', resolve));
+    rl.close();
     if (answer.trim().toLowerCase() !== 'y') {
       console.log('Scaffold cancelled. No files were changed.');
       return;

--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -13,7 +13,8 @@ import path from 'path';
  * RTK install script (universal Linux/macOS). Idempotent — re-running
  * upgrades RTK in place.
  */
-const RTK_INSTALL = 'curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh';
+// Pinned to v0.37.2 (80a6fe606f73b19e52b0b330d242e62a6c07be42) to prevent supply-chain risk from a mutable branch ref.
+const RTK_INSTALL = 'curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/80a6fe606f73b19e52b0b330d242e62a6c07be42/install.sh | sh';
 
 /**
  * Per-CLI `rtk init` invocation. RTK is universal but the init flag

--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -151,7 +151,6 @@ export function writeDevContainer(config, templateName, setupGitHub = false, _to
     finalConfig.mounts = [
       ...(finalConfig.mounts || []),
       { source: `gh-config-${slug}`, target: '/home/vscode/.config/gh', type: 'volume' },
-      { source: '${localWorkspaceFolder}/.ralph/token', target: '/tmp/ralph_token', type: 'bind', readonly: true },
     ];
 
     finalConfig.postStartCommand =

--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -27,19 +27,21 @@ const RTK_INIT_BY_CLI = {
 };
 
 /**
- * Caveman install command (Claude Code only). The plugin marketplace
- * install works without claude auth at container-create time.
+ * Caveman install command (Claude Code only). Guarded so the plugin
+ * marketplace registration and install are skipped when the `.claude`
+ * volume already contains the plugin from a prior build.
  */
 const CAVEMAN_INSTALL_CLAUDE =
-  'claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman';
+  '[ -d /home/vscode/.claude/plugins/caveman ] || (claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman)';
 
 /**
  * Shallow-clones the VoltAgent awesome-claude-code-subagents list into
- * the project-scoped `.claude/agents` volume. Claude Code discovers
- * agents there automatically.
+ * the project-scoped `.claude/agents` volume. Guarded so a second
+ * container build doesn't re-clone into an already-populated directory
+ * and break the `&&` chain.
  */
 const SUBAGENTS_CLONE =
-  'mkdir -p /home/vscode/.claude/agents && git clone --depth=1 https://github.com/VoltAgent/awesome-claude-code-subagents /home/vscode/.claude/agents/awesome-subagents';
+  '[ -d /home/vscode/.claude/agents/awesome-subagents ] || (mkdir -p /home/vscode/.claude/agents && git clone --depth=1 https://github.com/VoltAgent/awesome-claude-code-subagents /home/vscode/.claude/agents/awesome-subagents)';
 
 /**
  * VS Code settings that prevent the host's git credentials from being

--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -10,6 +10,38 @@ import fs from 'fs';
 import path from 'path';
 
 /**
+ * RTK install script (universal Linux/macOS). Idempotent — re-running
+ * upgrades RTK in place.
+ */
+const RTK_INSTALL = 'curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh';
+
+/**
+ * Per-CLI `rtk init` invocation. RTK is universal but the init flag
+ * selects which tool's config it rewrites.
+ */
+const RTK_INIT_BY_CLI = {
+  claude: 'rtk init -g',
+  codex: 'rtk init -g --codex',
+  gemini: 'rtk init -g --gemini',
+  opencode: 'rtk init -g --opencode',
+};
+
+/**
+ * Caveman install command (Claude Code only). The plugin marketplace
+ * install works without claude auth at container-create time.
+ */
+const CAVEMAN_INSTALL_CLAUDE =
+  'claude plugin marketplace add JuliusBrussee/caveman && claude plugin install caveman@caveman';
+
+/**
+ * Shallow-clones the VoltAgent awesome-claude-code-subagents list into
+ * the project-scoped `.claude/agents` volume. Claude Code discovers
+ * agents there automatically.
+ */
+const SUBAGENTS_CLONE =
+  'mkdir -p /home/vscode/.claude/agents && git clone --depth=1 https://github.com/VoltAgent/awesome-claude-code-subagents /home/vscode/.claude/agents/awesome-subagents';
+
+/**
  * VS Code settings that prevent the host's git credentials from being
  * forwarded into the container.
  */
@@ -54,13 +86,16 @@ function _projectSlug() {
 /**
  * Build and write `.devcontainer/devcontainer.json`.
  *
- * @param {object}  config        - Base devcontainer config from a template.
- * @param {string}  templateName  - Human-readable template name for log output.
- * @param {boolean} setupGitHub   - Whether to mount a PAT token and configure gh CLI.
- * @param {string|null} _tokenPath - Unused; kept for backward compatibility.
- * @param {string}      cliName   - The AI CLI selected by the user (e.g. 'claude').
+ * @param {object}  config           - Base devcontainer config from a template.
+ * @param {string}  templateName     - Human-readable template name for log output.
+ * @param {boolean} setupGitHub      - Whether to mount a PAT token and configure gh CLI.
+ * @param {string|null} _tokenPath   - Unused; kept for backward compatibility.
+ * @param {string}  cliName          - The AI CLI selected by the user (e.g. 'claude').
+ * @param {object}  [tools]          - Optional tool opt-ins.
+ * @param {boolean} [tools.caveman]  - Install the Caveman debugging plugin.
+ * @param {boolean} [tools.subagents] - Clone the awesome-claude-code-subagents list.
  */
-export function writeDevContainer(config, templateName, setupGitHub = false, _tokenPath = null, _debug = false, cliName = 'claude') {
+export function writeDevContainer(config, templateName, setupGitHub = false, _tokenPath = null, _debug = false, cliName = 'claude', tools = {}) {
   const devcontainerDir = path.resolve(process.cwd(), '.devcontainer');
   const devcontainerFile = path.join(devcontainerDir, 'devcontainer.json');
 
@@ -116,19 +151,22 @@ export function writeDevContainer(config, templateName, setupGitHub = false, _to
       { source: '${localWorkspaceFolder}/.ralph/token', target: '/tmp/ralph_token', type: 'bind', readonly: true },
     ];
 
-    const existingCommand = finalConfig.postCreateCommand || '';
-    const cleanupCommand = 'git config --global --unset-all credential.helper || true';
-    finalConfig.postCreateCommand = existingCommand
-      ? `${existingCommand} && ${cleanupCommand}`
-      : cleanupCommand;
-
     finalConfig.postStartCommand =
       'unset VSCODE_GIT_IPC_HANDLE GIT_ASKPASS VSCODE_GIT_ASKPASS_NODE VSCODE_GIT_ASKPASS_MAIN' +
       ' && git config --global --unset-all credential.helper || true' +
       ' && gh auth login --with-token < ${containerWorkspaceFolder}/.ralph/token && gh auth setup-git';
-  } else {
-    finalConfig.postCreateCommand = finalConfig.postCreateCommand || '';
   }
+
+  const additions = [
+    RTK_INSTALL,
+    RTK_INIT_BY_CLI[cliName] ?? RTK_INIT_BY_CLI.claude,
+  ];
+  if (tools.caveman && cliName === 'claude') additions.push(CAVEMAN_INSTALL_CLAUDE);
+  if (tools.subagents && cliName === 'claude') additions.push(SUBAGENTS_CLONE);
+  if (useGitHub) additions.push('git config --global --unset-all credential.helper || true');
+
+  const existingCommand = finalConfig.postCreateCommand || '';
+  finalConfig.postCreateCommand = [existingCommand, ...additions].filter(Boolean).join(' && ');
 
   fs.writeFileSync(devcontainerFile, JSON.stringify(finalConfig, null, 2));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-workflow",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "description": "scripts to get you started using Ralph workflow",
   "keywords": [
     "ralph"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "public"
   ],
   "scripts": {
-    "test": "vitest",
+    "test": "vitest run",
+    "testwatch": "vitest",
     "test:ui": "vitest --ui",
     "docs:build": "cd docs && npm run build"
   },


### PR DESCRIPTION
## Summary

This release collects all changes merged into `release/2.0.4` since v2.0.3.

### Included PRs

- #17 — fix: warn and prompt before overwriting existing scripts/ directory
- #20 — fix: grant write permissions to GitHub Actions for PR comments
- #21 — chore: bump version to 2.0.3 in package.json
- #22 — fix: retry on repo creation failure + upfront notice (#18)
- #23 — feat: auto-install RTK and add opt-in Caveman + subagents (#14)
- #25 — fix: pin RTK install script to v0.37.2 commit SHA
- #26 — refactor: decouple GitHub setup from devcontainer installs (idempotent guards)

### Additional changes

- ci: add test workflow required to pass before merging PR
- doc: add guidelines for handling failing tests in CLAUDE.md
- fix: remove ralph token bind mount from devcontainer (vscode binds entire workspace by default)

## Test plan

- [x] All CI checks pass on `release/2.0.4`
- [x] RTK auto-install and opt-in Caveman/subagents work as expected
- [x] Re-running setup is idempotent (no duplicate installs)
- [x] GitHub repo creation retries on failure and shows upfront notice
- [x] GitHub Actions workflows have correct write permissions for PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)