### PR TITLE
docs: reflect v2.0.4 wizard flow, RTK auto-install, and Claude extras

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -9,12 +9,12 @@ const features = [
   {
     title: 'Dev Container Templates',
     description:
-      'Leveraging VSCode Dev container to provide isolation for ralph loop. scaffold template pre-configures isolation, dependency, scripts to start coding immediately.',
+      'Leveraging VSCode Dev container to provide isolation for ralph loop. Scaffolded templates pre-configure isolation, dependencies, and auto-install RTK with rtk init already run for your chosen CLI so token-reduction kicks in on first boot. For Claude, opt in to the Caveman debug plugin and the awesome-claude-code-subagents collection.',
   },
   {
     title: 'Credential Isolation',
     description:
-      'ralph-workflow provides convenience to passing github PAT token if ralph needs it, perform credential cleaning within container programmatically',
+      'ralph-workflow provides convenience to passing github PAT token if ralph needs it, perform credential cleaning within container programmatically. GitHub setup is now independent from the Dev Container — pick either, both, or neither.',
   },
   {
     title: 'Ralph Task Loop',
@@ -87,14 +87,18 @@ export default function Home() {
           <pre className="bg-black/40 border border-white/10 text-green-400 rounded-lg p-6 overflow-x-auto text-sm leading-relaxed">
             <code>{`$ npx ralph-workflow
 
+? Which AI coding CLI? (claude/codex/gemini/opencode) claude
 ? Set up VS Code Dev Container for isolation? (Y/n) Y
-? Choose a Dev Container template: Node 20
 ? Set up GitHub repository with isolated PAT? (Y/n) Y
+? Install Caveman debugging plugin? (y/N) n
+? Install curated awesome-claude-code-subagents collection? (y/N) n
+? Choose a Dev Container template: Node 20
   → Open https://github.com/settings/personal-access-tokens/new
   → Select only this repository, grant Contents: write
 ? Paste your PAT: **********************************
 
 ✓ .devcontainer/devcontainer.json written
+✓ RTK + rtk init queued in postCreateCommand
 ✓ scripts/ralph/ scaffolded
 ✓ PAT stored at .ralph/token (gitignored, mode 0600)
 

--- a/docs/app/usage-guide/page.tsx
+++ b/docs/app/usage-guide/page.tsx
@@ -60,15 +60,16 @@ const promptMdCode = `# Ralph Agent Instructions
 8. Append learnings to progress.txt`
 
 const projectStructureCode = `bin/
-├── cli.js                          # entry point — main() and top-level flow
+├── cli.js                          # entry point — orchestrates prompts and setup steps
 ├── commands/
-│   ├── devcontainer.js             # template picker + GitHub question
-│   ├── github-access.js            # PAT creation and storage
-│   └── scaffold.js                 # copies templates into scripts/ralph/
+│   ├── devcontainer.js             # template picker (selectTemplate)
+│   ├── github-access.js            # git repo + GitHub repo + PAT setup (with retry)
+│   └── scaffold.js                 # copies templates into scripts/ralph/ (with overwrite prompt)
 ├── lib/
 │   ├── ui.js                       # ask() and selectMenu() terminal helpers
 │   ├── devcontainer-templates.js   # the 5 container image definitions
-│   └── write-devcontainer.js       # builds and writes devcontainer.json
+│   └── write-devcontainer.js       # builds devcontainer.json — RTK install, per-CLI rtk init,
+│                                   #   optional Caveman / subagents (Claude only)
 └── scripts/
     ├── validate-isolation.sh.js    # embedded shell script (quick token check)
     └── check-isolation.sh.js       # embedded shell script (full isolation audit)
@@ -107,12 +108,18 @@ export default function UsageGuidePage() {
         </p>
         <CodeBlock lang="bash">{`mkdir my-project && cd my-project
 npx ralph-workflow`}</CodeBlock>
-        <p className="text-gray-400 text-sm mb-2">The wizard will ask:</p>
+        <p className="text-gray-400 text-sm mb-2">The wizard will ask, in order:</p>
         <ol className="list-decimal pl-5 space-y-2 text-gray-400 text-sm">
-          <li><strong className="text-gray-200">Dev Container template</strong> — choose Node, Python, Ubuntu, etc.</li>
-          <li><strong className="text-gray-200">GitHub access</strong> — optionally create a fine-grained PAT scoped to one repo.</li>
-          <li><strong className="text-gray-200">AI CLI</strong> — pick claude, codex, gemini, or opencode.</li>
+          <li><strong className="text-gray-200">AI CLI</strong> — pick claude, codex, gemini, or opencode. This choice drives the matching <code className="bg-white/10 text-brand-purple px-1 rounded">rtk init</code> flag below.</li>
+          <li><strong className="text-gray-200">Dev Container isolation</strong> — set up a VS Code Dev Container so the host's credentials are not forwarded in.</li>
+          <li><strong className="text-gray-200">GitHub access</strong> — optionally create a fine-grained PAT scoped to one repo. This is now <em>independent</em> of the Dev Container choice, so you can have isolation without a PAT, a PAT without isolation, both, or neither.</li>
+          <li><strong className="text-gray-200">Claude extras</strong> (only if you picked <code className="bg-white/10 text-brand-purple px-1 rounded">claude</code>) — opt in to the <a href="https://github.com/JuliusBrussee/caveman" className="text-brand-purple underline">Caveman</a> debugging plugin and/or the <a href="https://github.com/VoltAgent/awesome-claude-code-subagents" className="text-brand-purple underline">awesome-claude-code-subagents</a> collection. Both default to no.</li>
+          <li><strong className="text-gray-200">Dev Container template</strong> (only if isolation is enabled) — choose Node, Python, Ubuntu, etc.</li>
         </ol>
+        <p className="text-gray-400 text-sm mt-3">
+          If <code className="bg-white/10 text-brand-purple px-1 rounded">scripts/</code> already exists in your project, the scaffold step
+          warns you and asks for confirmation before overwriting anything.
+        </p>
       </section>
 
       {/* Set up isolation */}
@@ -184,6 +191,44 @@ claude                                     # log in
 claude --dangerously-skip-permissions      # accept the warning once`}</CodeBlock>
         <p className="text-gray-400 text-sm">
           The <code className="bg-white/10 text-brand-purple px-1 rounded">--dangerously-skip-permissions</code> acceptance only needs to happen once per container.
+        </p>
+      </section>
+
+      {/* RTK + Claude extras */}
+      <section className="mb-10">
+        <h2 className="text-2xl font-semibold mb-3 text-brand-purple">RTK and Claude-only Extras</h2>
+        <p className="text-gray-400 text-sm mb-3">
+          Every generated <code className="bg-white/10 text-brand-purple px-1 rounded">devcontainer.json</code> auto-installs
+          {' '}<a href="https://github.com/rtk-ai/rtk" className="text-brand-purple underline">RTK</a> and runs the per-CLI{' '}
+          <code className="bg-white/10 text-brand-purple px-1 rounded">rtk init</code> variant via
+          {' '}<code className="bg-white/10 text-brand-purple px-1 rounded">postCreateCommand</code>. The install script is pinned to a
+          specific commit SHA to avoid supply-chain drift, and the init command is idempotent — re-running a container rebuild
+          won't duplicate anything.
+        </p>
+        <CodeBlock lang="bash">{`# Per-CLI rtk init selected automatically
+claude    → rtk init -g
+codex     → rtk init -g --codex
+gemini    → rtk init -g --gemini
+opencode  → rtk init -g --opencode`}</CodeBlock>
+        <p className="text-gray-400 text-sm mb-3">
+          If you picked <code className="bg-white/10 text-brand-purple px-1 rounded">claude</code> as your CLI, two optional extras are available:
+        </p>
+        <ul className="list-disc pl-5 space-y-2 text-gray-400 text-sm">
+          <li>
+            <strong className="text-gray-200">Caveman</strong> — the <a href="https://github.com/JuliusBrussee/caveman" className="text-brand-purple underline">Caveman</a> plugin is registered and installed via{' '}
+            <code className="bg-white/10 text-brand-purple px-1 rounded">claude plugin install caveman@caveman</code>. Guarded so an existing install in the{' '}
+            <code className="bg-white/10 text-brand-purple px-1 rounded">.claude</code> volume is not reinstalled on rebuild.
+          </li>
+          <li>
+            <strong className="text-gray-200">awesome-claude-code-subagents</strong> — a shallow clone of{' '}
+            <a href="https://github.com/VoltAgent/awesome-claude-code-subagents" className="text-brand-purple underline">VoltAgent's curated list</a> into{' '}
+            <code className="bg-white/10 text-brand-purple px-1 rounded">/home/vscode/.claude/agents/awesome-subagents</code>, which lives
+            inside the project-scoped <code className="bg-white/10 text-brand-purple px-1 rounded">.claude</code> Docker volume and persists across rebuilds.
+          </li>
+        </ul>
+        <p className="text-gray-400 text-sm mt-3">
+          Both extras default to <em>no</em> and are gated on <code className="bg-white/10 text-brand-purple px-1 rounded">cliName === 'claude'</code>; the prompts
+          are simply skipped for other CLIs.
         </p>
       </section>
 

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,10 @@ Ralph runs with `--dangerously-skip-permissions`. Without isolation, it operates
 Running the CLI will:
 
 1. **Optionally set up a VS Code Dev Container** — picks a base image (Node, Python, etc.) and applies credential-isolation settings so the host's SSH keys, GitHub tokens, and cloud credentials are not forwarded into the container.
-2. **Optionally create a scoped GitHub PAT** — walks you through generating a fine-grained token restricted to just this repository. The token is stored in `.ralph/token` inside your project (automatically gitignored, mode 0600) and bind-mounted into the container using a cross-platform path — works on macOS, Linux, and Windows.
-3. **Scaffold Ralph scripts** into `scripts/ralph/` — the loop script, prompt template, task list, and progress log.
+2. **Optionally create a scoped GitHub PAT** — walks you through generating a fine-grained token restricted to just this repository. The token is stored in `.ralph/token` inside your project (automatically gitignored, mode 0600) and reaches the container through the workspace bind — works on macOS, Linux, and Windows. GitHub setup is independent of the Dev Container choice; you can opt into either, both, or neither.
+3. **Auto-install [RTK](https://github.com/rtk-ai/rtk)** — RTK is installed into every Dev Container and `rtk init` is run for the CLI you picked (claude, codex, gemini, or opencode) so token-reduction kicks in on first boot.
+4. **Optionally install Claude-only extras** — when the selected CLI is `claude`, you can opt in to the [Caveman](https://github.com/JuliusBrussee/caveman) debugging plugin and the [awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) collection. Both default to off and persist in a project-scoped `.claude` volume across rebuilds.
+5. **Scaffold Ralph scripts** into `scripts/ralph/` — the loop script, prompt template, task list, and progress log. If `scripts/` already exists, you'll be asked to confirm before anything is overwritten.
 
 ## Get Involved
 We welcome issues and pull requests!


### PR DESCRIPTION
## Summary
- Rewrite **readme.md** \"What it does\" to cover the v2.0.4 wizard: GitHub setup decoupled from Dev Container, RTK auto-install with per-CLI `rtk init`, Claude-only Caveman / awesome-subagents opt-ins, and the `scripts/` overwrite confirmation.
- Update **docs site landing page** Quick Start transcript to show the real prompt order (CLI → isolation → GitHub → Caveman → subagents → template) and fold the RTK / Claude-extras story into the Dev Container Templates feature card.
- Update **docs site usage guide** wizard list to match the real flow, add a new \"RTK and Claude-only Extras\" section with the per-CLI init table, and refresh the project-structure snippet to match the refactored `commands/*.js`.

## Test plan
- [x] `npx tsc --noEmit` passes in `docs/`
- [x] Visually check the rendered pages (`npm run docs:build` / preview) for typography and layout
- [x] Sanity-read readme on GitHub after merge