### PR TITLE
fix: auto-create initial commit before gh repo create --push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,15 @@
 ## When a test is failing
 
 Before changing implementation code, check `git log`/`git blame` to understand why it was written that way. Fix the test to match the implementation unless the implementation is clearly wrong.
+
+## PR: fix: auto-create initial commit before `gh repo create --push`
+
+### Summary
+- `setupGitHubAccess` ran `gh repo create "<name>" --private --source=. --push` against fresh project directories that had a freshly-`git init`'d repo with zero commits. `gh` aborts in that case with `--push enabled but no commits found in <path>`, which made `npx ralph-workflow` against an empty directory fail.
+- Added `_ensureInitialCommit(projectName)` in `bin/commands/github-access.js`. It runs after `_ensureGitRepo()` and before any `gh` calls: if `git rev-parse HEAD` shows no commits, it stages everything (creating a `README.md` placeholder when the working tree is also empty) and creates a `chore: initial commit`.
+- Bumped `package.json` to `2.0.6`.
+
+### Test plan
+- [ ] `npx ralph-workflow` in an empty directory → repo gets created, initial commit pushed, no `--push enabled but no commits found` error.
+- [ ] `npx ralph-workflow` in a directory that already has commits → no extra commit created.
+- [ ] `npx ralph-workflow` in a directory with unstaged files but no commits → those files end up in the initial commit (no placeholder README written).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,15 +3,3 @@
 ## When a test is failing
 
 Before changing implementation code, check `git log`/`git blame` to understand why it was written that way. Fix the test to match the implementation unless the implementation is clearly wrong.
-
-## PR: fix: auto-create initial commit before `gh repo create --push`
-
-### Summary
-- `setupGitHubAccess` ran `gh repo create "<name>" --private --source=. --push` against fresh project directories that had a freshly-`git init`'d repo with zero commits. `gh` aborts in that case with `--push enabled but no commits found in <path>`, which made `npx ralph-workflow` against an empty directory fail.
-- Added `_ensureInitialCommit(projectName)` in `bin/commands/github-access.js`. It runs after `_ensureGitRepo()` and before any `gh` calls: if `git rev-parse HEAD` shows no commits, it stages everything (creating a `README.md` placeholder when the working tree is also empty) and creates a `chore: initial commit`.
-- Bumped `package.json` to `2.0.6`.
-
-### Test plan
-- [ ] `npx ralph-workflow` in an empty directory → repo gets created, initial commit pushed, no `--push enabled but no commits found` error.
-- [ ] `npx ralph-workflow` in a directory that already has commits → no extra commit created.
-- [ ] `npx ralph-workflow` in a directory with unstaged files but no commits → those files end up in the initial commit (no placeholder README written).

--- a/bin/commands/github-access.js
+++ b/bin/commands/github-access.js
@@ -28,6 +28,7 @@ export async function setupGitHubAccess() {
   console.log(`\nSetting up GitHub isolation for project: ${projectName}`);
 
   _ensureGitRepo();
+  _ensureInitialCommit(projectName);
 
   const userName = await _getGitHubUsername(ask);
 
@@ -48,6 +49,38 @@ function _ensureGitRepo() {
     console.log('Initializing git repository...');
     execSync('git init -b main 2>/dev/null || git init 2>/dev/null', { stdio: 'inherit' });
   }
+}
+
+/**
+ * Ensure the repo has at least one commit so `gh repo create --push` succeeds.
+ *
+ * `gh repo create --source=. --push` refuses to run when the local repo has
+ * zero commits ("--push enabled but no commits found"). On a fresh `npx
+ * ralph-workflow` run against an empty directory, the working tree may be
+ * empty or only contain unstaged files, so we create a README placeholder
+ * if needed and create an initial commit.
+ *
+ * @param {string} projectName
+ */
+function _ensureInitialCommit(projectName) {
+  try {
+    execSync('git rev-parse HEAD', { stdio: 'pipe' });
+    return; // at least one commit already exists
+  } catch {
+    // no commits yet — fall through
+  }
+
+  const readmePath = path.join(process.cwd(), 'README.md');
+  if (!fs.existsSync(readmePath)) {
+    const hasAnyTrackable = execSync('git status --porcelain', { encoding: 'utf8' }).trim().length > 0;
+    if (!hasAnyTrackable) {
+      fs.writeFileSync(readmePath, `# ${projectName}\n`);
+    }
+  }
+
+  console.log('Creating initial commit so the new GitHub repo has something to push...');
+  execSync('git add -A', { stdio: 'inherit' });
+  execSync('git commit -m "chore: initial commit"', { stdio: 'inherit' });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-workflow",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "scripts to get you started using Ralph workflow",
   "keywords": [
     "ralph"


### PR DESCRIPTION
Closes #37

## Summary
- `setupGitHubAccess` ran `gh repo create "<name>" --private --source=. --push` against fresh project directories that had a freshly-`git init`'d repo with zero commits. `gh` aborts in that case with `--push enabled but no commits found in <path>`, which made `npx ralph-workflow` against an empty directory fail.
- Added `_ensureInitialCommit(projectName)` in `bin/commands/github-access.js`. Runs after `_ensureGitRepo()` and before any `gh` calls: if `git rev-parse HEAD` shows no commits, stages everything (writing a `README.md` placeholder when the working tree is also empty) and creates a `chore: initial commit`.
- Bumped `package.json` to `2.0.6`.

## Test plan
- [x] `npx ralph-workflow` in an empty directory → repo gets created, initial commit pushed, no `--push enabled but no commits found` error.
- [x] `npx ralph-workflow` in a directory that already has commits → no extra commit created.
- [x] `npx ralph-workflow` in a directory with unstaged files but no commits → those files end up in the initial commit (no placeholder README written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)