### PR TITLE
release: v2.0.7

### DIFF
--- a/.claude/commands/release-pr.md
+++ b/.claude/commands/release-pr.md
@@ -1,0 +1,63 @@
+---
+description: Write release PR notes with linked issues, features, and fixes
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh pr edit:*), Bash(git log:*), Bash(cat:*)
+---
+
+Write or update release PR notes for the current branch.
+
+## Steps
+
+1. **Detect PR**: run `gh pr view --json number,title,body,commits` for current branch. If no PR, ask user for PR number.
+
+2. **Extract version**: read `package.json` for `"version"` field.
+
+3. **Map commits to issues**: for each commit:
+   - Parse branch names like `feat/31-*` or `fix/33-*` → extract issue number
+   - Parse commit message refs like `(#31)`, `Closes #31`, `Refs #31`
+   - Collect unique issue numbers
+
+4. **Fetch issue details**: for each issue number, run `gh issue view <number> --json number,title,state`. Use title as description.
+
+5. **Categorize changes**:
+   - `feat` commits → Features section
+   - `fix` commits → Fixes section
+   - `refactor`/`chore`/`docs` → Other Changes section (omit if empty)
+
+6. **Check CI status**: `gh pr view --json statusCheckRollup` → build check table
+
+7. **Write PR body** in this format:
+
+```markdown
+## v<VERSION>
+
+### Features
+
+- **<short title>** — <one-sentence description>.
+  Closes #<N>
+
+### Fixes
+
+- **<short title>** — <one-sentence description>.
+  Closes #<N>
+
+### Checks
+
+| Check | Status |
+|-------|--------|
+| <check-name> | ✅ passing / ❌ failing / ⏳ in progress |
+```
+
+8. **Apply**: run `gh pr edit <number> --body "<body>"` to update the PR.
+
+## Rules
+
+- Every issue referenced in a commit MUST appear under `Closes #N` in the body
+- If an issue is CLOSED already, still include `Closes #N` — it's the canonical link
+- If no issue exists for a commit, write the commit summary inline without a `Closes` line
+- Version comes from `package.json`, not branch name
+- Keep descriptions one sentence. No hedging words. No "this PR".
+- Check table: show all CI checks. Map status: `SUCCESS` → ✅, `FAILURE` → ❌, `IN_PROGRESS` → ⏳, missing → ⏳
+
+## Trigger
+
+User says: "write release PR notes", "update release PR", "make release details", "/release-pr", or asks to fill in PR body for a release branch.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
-  "name": "Node.js",
+  "name": "ralph-workflow",
+  "runArgs": ["--name", "${localWorkspaceFolderBasename}-dev"],
   "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "remoteEnv": {

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,7 +12,7 @@ If you've contributed to this project, we'd love to have you listed here! Simply
 
 ## Core Contributors
 
-- [Rickvian Aldi](https://rickvianaldi.com) ([@rickvian](https://github.com/rickvian)) - Creator and maintainer of Ralph Workflow
+- [Rickvian Aldi](https://rickvianaldi.com) ([@rickvian](https://github.com/rickvian))
 
 ## Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,7 +12,7 @@ If you've contributed to this project, we'd love to have you listed here! Simply
 
 ## Core Contributors
 
-- [@rickvian](https://github.com/rickvian) - Creator and maintainer of Ralph Workflow
+- [Rickvian Aldi](https://rickvianaldi.com) ([@rickvian](https://github.com/rickvian)) - Creator and maintainer of Ralph Workflow
 
 ## Contributors
 

--- a/__tests__/scaffold.test.js
+++ b/__tests__/scaffold.test.js
@@ -99,6 +99,22 @@ describe('scaffoldRalph', () => {
     }
   });
 
+  it('should create .ralph-version file with package version', async () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+      await scaffoldRalph('claude');
+
+      const versionFilePath = path.join(TEST_DIR, 'scripts', 'ralph', '.ralph-version');
+      expect(fs.existsSync(versionFilePath)).toBe(true);
+
+      const content = fs.readFileSync(versionFilePath, 'utf-8').trim();
+      expect(content).toMatch(/^ralph-workflow@\d+\.\d+\.\d+$/);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it('should warn and prompt when scripts/ already exists, then overwrite on confirm', async () => {
     mockQuestion.mockImplementation((_prompt, cb) => cb('y'));
     const originalCwd = process.cwd();

--- a/__tests__/write-devcontainer.test.js
+++ b/__tests__/write-devcontainer.test.js
@@ -208,6 +208,25 @@ describe('writeDevContainer', () => {
     }
   });
 
+  it('registers Playwright MCP only when opted in and cliName is claude', () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude', { playwrightMcp: true });
+      expect(readGeneratedScript('post-create.sh')).toContain('claude mcp add playwright');
+      expect(readGeneratedScript('post-create.sh')).toContain('@playwright/mcp');
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude');
+      expect(readGeneratedScript('post-create.sh')).not.toContain('@playwright/mcp');
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'gemini', { playwrightMcp: true });
+      expect(readGeneratedScript('post-create.sh')).not.toContain('@playwright/mcp');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it('writes remoteUser matching the template base image (Node.js → node)', () => {
     const originalCwd = process.cwd();
     try {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -107,6 +107,12 @@ async function main() {
     wantsSubagents = subagentsAnswer.trim().toLowerCase() === 'y';
   }
 
+  let wantsPlaywrightMcp = false;
+  if (cliName === 'claude') {
+    const playwrightAnswer = await ask('Install Playwright MCP server? [y/N]: ');
+    wantsPlaywrightMcp = playwrightAnswer.trim().toLowerCase() === 'y';
+  }
+
   // Template selection uses raw keypress mode and closes rl — must come after all ask() calls.
   let template = null;
   if (wantsIsolation) {
@@ -115,7 +121,7 @@ async function main() {
     rl.close();
   }
 
-  const tools = { caveman: wantsCaveman, subagents: wantsSubagents };
+  const tools = { caveman: wantsCaveman, subagents: wantsSubagents, playwrightMcp: wantsPlaywrightMcp };
 
   if (!wantsIsolation && !wantsGitHub) {
     console.log('\n  ⚠️  Proceeding without isolation. Be careful.\n');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,7 +29,7 @@ const { version } = require('../package.json');
 
 const DEBUG = process.argv.includes('--check-isolation');
 
-// Interpolates two RGB colours across the characters of a string using ANSI true-colour codes.
+// Interpolates two RGB colors across the characters of a string using ANSI true-color codes.
 function gradient(text, [r1, g1, b1], [r2, g2, b2]) {
   const len = text.length;
   return text.split('').map((ch, i) => {

--- a/bin/commands/scaffold.js
+++ b/bin/commands/scaffold.js
@@ -16,6 +16,10 @@ import { writeRalphSh } from '../lib/generate-ralph-sh.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const { version: RALPH_VERSION } = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf-8')
+);
+
 /** Absolute path to the bundled templates/scripts directory (two levels up from commands/). */
 const SOURCE_DIR = path.resolve(__dirname, '../../templates/scripts');
 
@@ -65,6 +69,10 @@ export async function scaffoldRalph(cliName = 'claude') {
 
     // Make ralph.sh executable
     fs.chmodSync(ralphShPath, 0o755);
+
+    // Record the scaffolding version so users can tell which release was used
+    const versionFilePath = path.join(targetRalphDir, '.ralph-version');
+    fs.writeFileSync(versionFilePath, 'ralph-workflow@' + RALPH_VERSION + '\n', 'utf-8');
 
     console.log("'scripts' directory has been created");
     console.log('\nYou can now use the Ralph scripts in your workflow.');

--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -41,6 +41,10 @@ const CAVEMAN_INSTALL_CLAUDE =
 const SUBAGENTS_CLONE =
   '[ -d "$HOME/.claude/agents/awesome-subagents" ] || (mkdir -p "$HOME/.claude/agents" && git clone --depth=1 https://github.com/VoltAgent/awesome-claude-code-subagents "$HOME/.claude/agents/awesome-subagents")';
 
+// Guarded so a rebuilt volume skips re-registration if already present.
+const PLAYWRIGHT_MCP_INSTALL =
+  'claude mcp get playwright 2>/dev/null || claude mcp add playwright -- npx @playwright/mcp@latest';
+
 const ISOLATION_VSCODE_SETTINGS = {
   'git.terminalAuthentication': false,
   'github.gitAuthentication': false,
@@ -99,7 +103,7 @@ function _projectSlug() {
  * Build the content of .devcontainer/post-create.sh.
  * Each step is a separate line with a comment explaining why it exists.
  */
-function _buildPostCreateScript({ cliInstall, fixOwnership, rtkInstall, rtkInit, caveman, subagents, credCleanup }) {
+function _buildPostCreateScript({ cliInstall, fixOwnership, rtkInstall, rtkInit, caveman, subagents, playwrightMcp, credCleanup }) {
   const sections = [
     [
       '#!/usr/bin/env bash',
@@ -146,6 +150,13 @@ function _buildPostCreateScript({ cliInstall, fixOwnership, rtkInstall, rtkInit,
     ]);
   }
 
+  if (playwrightMcp) {
+    sections.push([
+      '# Register Playwright MCP server with Claude Code (guarded so a rebuilt volume skips re-registration)',
+      playwrightMcp,
+    ]);
+  }
+
   if (credCleanup) {
     sections.push([
       '# Remove the VS Code credential helper injected at container build time',
@@ -188,8 +199,9 @@ function _buildPostStartScript() {
  * @param {string|null} _tokenPath   - Unused; kept for backward compatibility.
  * @param {string}  cliName          - The AI CLI selected by the user (e.g. 'claude').
  * @param {object}  [tools]          - Optional tool opt-ins.
- * @param {boolean} [tools.caveman]  - Install the Caveman debugging plugin.
- * @param {boolean} [tools.subagents] - Clone the awesome-claude-code-subagents list.
+ * @param {boolean} [tools.caveman]       - Install the Caveman debugging plugin.
+ * @param {boolean} [tools.subagents]     - Clone the awesome-claude-code-subagents list.
+ * @param {boolean} [tools.playwrightMcp] - Register the Playwright MCP server with Claude Code.
  */
 export function writeDevContainer(config, templateName, setupGitHub = false, _tokenPath = null, _debug = false, cliName = 'claude', tools = {}) {
   const devcontainerDir = path.resolve(process.cwd(), '.devcontainer');
@@ -269,6 +281,7 @@ export function writeDevContainer(config, templateName, setupGitHub = false, _to
     rtkInit: RTK_INIT_BY_CLI[cliName] ?? RTK_INIT_BY_CLI.claude,
     caveman: (tools.caveman && cliName === 'claude') ? CAVEMAN_INSTALL_CLAUDE : null,
     subagents: (tools.subagents && cliName === 'claude') ? SUBAGENTS_CLONE : null,
+    playwrightMcp: (tools.playwrightMcp && cliName === 'claude') ? PLAYWRIGHT_MCP_INSTALL : null,
     credCleanup: useGitHub ? 'git config --global --unset-all credential.helper || true' : null,
   });
 

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -79,7 +79,7 @@ export default function Home() {
       </section>
 
       {/* Quick Start */}
-      <section className="py-16 px-4">
+      <section className="py-16 px-4 border-b border-white/10">
         <div className="max-w-5xl mx-auto">
           <h2 className="text-2xl sm:text-3xl font-bold text-center mb-8">
             Quick Start
@@ -113,6 +113,39 @@ Reopen this folder in the Dev Container to start.`}</code>
               Full guide →
             </Link>
           </p>
+        </div>
+      </section>
+
+      {/* Contributors */}
+      <section className="py-16 px-4">
+        <div className="max-w-5xl mx-auto text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold mb-4">Contributors</h2>
+          <p className="text-gray-400 mb-8 max-w-xl mx-auto text-sm">
+            Built by the community. Every bug report, PR, and idea counts.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4 mb-10">
+            <a
+              href="https://rickvianaldi.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 bg-white/5 border border-white/10 rounded-lg px-4 py-2 hover:border-brand-purple transition-colors text-sm"
+            >
+              <img
+                src="https://github.com/rickvian.png"
+                alt="rickvian"
+                className="w-6 h-6 rounded-full"
+              />
+              <span className="text-gray-200">Rickvian Aldi</span>
+            </a>
+          </div>
+          <a
+            href="https://github.com/rickvian/ralph-workflow/blob/main/CONTRIBUTING.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block border border-brand-purple text-brand-purple font-semibold px-6 py-3 rounded hover:bg-brand-purple hover:text-brand-bg transition-colors"
+          >
+            Become a contributor ↗
+          </a>
         </div>
       </section>
     </>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ralph-workflow",
-  "version": "2.0.5",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ralph-workflow",
-      "version": "2.0.5",
+      "version": "2.0.7",
       "license": "MIT",
       "bin": {
         "ralph-workflow": "bin/cli.js"
@@ -16,21 +16,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -57,14 +57,14 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
       "cpu": [
         "arm64"
       ],
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
       "cpu": [
         "x64"
       ],
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
       "cpu": [
         "arm"
       ],
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
       ],
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
       "cpu": [
         "ppc64"
       ],
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
       ],
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
       "cpu": [
         "x64"
       ],
@@ -256,9 +256,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
       ],
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
       "cpu": [
         "arm64"
       ],
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
       "cpu": [
         "wasm32"
       ],
@@ -300,18 +300,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
       "cpu": [
         "arm64"
       ],
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
       "cpu": [
         "x64"
       ],
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -357,9 +357,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -951,7 +951,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -960,14 +960,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -976,21 +976,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
     "node_modules/siginfo": {
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1077,17 +1077,17 @@
       "optional": true
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1103,7 +1103,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-workflow",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "scripts to get you started using Ralph workflow",
   "keywords": [
     "ralph"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "url": "git+https://github.com/rickvian/ralph-workflow.git"
   },
   "license": "MIT",
-  "author": "Rickvian",
+  "author": {
+    "name": "Rickvian Aldi",
+    "url": "https://rickvianaldi.com"
+  },
   "type": "module",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## v2.0.7

### Features

- **Gemini CLI installation** — adds install logic for `gemini` CLI with tests.

- **Playwright MCP optional setup** — adds a Claude-only wizard prompt to install the Playwright MCP server, then registers it idempotently in `post-create.sh` when selected.
  Closes #48. Included via #49.

- **Scaffold version marker** — writes `scripts/ralph/.ralph-version` during scaffold using the package version from `package.json`, with test coverage for the generated marker format.
  Closes #43. Included via #44.

### Fixes

- **RTK telemetry in non-interactive builds** — silences prompt during container rebuild so `postCreateCommand` no longer hangs.
  Closes #33.

- **`gh repo create --push` on empty projects** — auto-creates initial commit before invoking `gh`, so `npx ralph-workflow` works from a blank directory.
  Closes #37.

- **Predictable devcontainer names** — adds `runArgs` using `${localWorkspaceFolderBasename}-dev` so scaffolded projects get stable Docker container names instead of random Docker-assigned names.
  Closes #41. Included via #42.

- **cSpell cleanup** — switches the `gradient()` comment from British to American spelling (`colour`/`colours` → `color`/`colors`) with no runtime behavior change.
  Closes #46. Included via #47.

### Other Changes

- **Extract setup scripts** — `postCreateCommand` one-liner split into `post-create.sh` / `post-start.sh`. Each step commentable, debuggable via `set -euo pipefail`.
  Closes #31.

- **Release PR command** — adds `/release-pr` slash command at `.claude/commands/release-pr.md` for writing structured release notes with linked issues.

- **Package metadata and contributors** — expands the npm `author` field to include Rickvian Aldi's name and website, updates contributor display, and reflects the contributor section on the docs homepage.
  Included via #45.

- **Dependency lockfile refresh** — updates `package-lock.json` for v2.0.7 dependency metadata.

### Recently Merged Into This Release Branch

| PR | Merged | Summary |
|----|--------|---------|
| #42 | 2026-06-26 | Stable devcontainer container naming from project folder |
| #44 | 2026-06-26 | `.ralph-version` scaffold marker |
| #45 | 2026-06-26 | Author metadata and contributor docs updates |
| #47 | 2026-05-12 | cSpell spelling cleanup in `gradient()` comment |
| #49 | 2026-05-12 | Optional Claude Playwright MCP setup |

### Checks

| Check | Status |
|-------|--------|
| Tests | ⏳ pending |
| Claude review | ⏳ pending |