### PR TITLE
fix: use project folder name as devcontainer container name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
-  "name": "Node.js",
+  "name": "ralph-workflow",
+  "runArgs": ["--name", "${localWorkspaceFolderBasename}-dev"],
   "image": "mcr.microsoft.com/devcontainers/javascript-node:24",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "remoteEnv": {


### PR DESCRIPTION
## Summary

- Adds `runArgs` to `.devcontainer/devcontainer.json` with `${localWorkspaceFolderBasename}-dev` so scaffolded projects get predictable container names
- If container name conflicts, Docker errors with clear message — user deletes conflicting container or renames folder

Closes #41