### PR TITLE
feat: write .ralph-version file during scaffold

### DIFF
--- a/__tests__/scaffold.test.js
+++ b/__tests__/scaffold.test.js
@@ -99,6 +99,22 @@ describe('scaffoldRalph', () => {
     }
   });
 
+  it('should create .ralph-version file with package version', async () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+      await scaffoldRalph('claude');
+
+      const versionFilePath = path.join(TEST_DIR, 'scripts', 'ralph', '.ralph-version');
+      expect(fs.existsSync(versionFilePath)).toBe(true);
+
+      const content = fs.readFileSync(versionFilePath, 'utf-8').trim();
+      expect(content).toMatch(/^ralph-workflow@\d+\.\d+\.\d+$/);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it('should warn and prompt when scripts/ already exists, then overwrite on confirm', async () => {
     mockQuestion.mockImplementation((_prompt, cb) => cb('y'));
     const originalCwd = process.cwd();

--- a/bin/commands/scaffold.js
+++ b/bin/commands/scaffold.js
@@ -16,6 +16,10 @@ import { writeRalphSh } from '../lib/generate-ralph-sh.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const { version: RALPH_VERSION } = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'utf-8')
+);
+
 /** Absolute path to the bundled templates/scripts directory (two levels up from commands/). */
 const SOURCE_DIR = path.resolve(__dirname, '../../templates/scripts');
 
@@ -65,6 +69,10 @@ export async function scaffoldRalph(cliName = 'claude') {
 
     // Make ralph.sh executable
     fs.chmodSync(ralphShPath, 0o755);
+
+    // Record the scaffolding version so users can tell which release was used
+    const versionFilePath = path.join(targetRalphDir, '.ralph-version');
+    fs.writeFileSync(versionFilePath, 'ralph-workflow@' + RALPH_VERSION + '\n', 'utf-8');
 
     console.log("'scripts' directory has been created");
     console.log('\nYou can now use the Ralph scripts in your workflow.');


### PR DESCRIPTION
## Summary

- Writes `scripts/ralph/.ralph-version` (e.g. `ralph-workflow@2.0.7`) after every scaffold
- Version read dynamically from `package.json` at scaffold time — always accurate
- Adds test verifying file exists and matches `ralph-workflow@X.Y.Z` format

Closes #43

## Test plan

- [ ] `npm test` passes (25/25)
- [ ] `ralph-workflow scaffold` creates `scripts/ralph/.ralph-version` with correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)