### PR TITLE
fix: use American English spelling in gradient() comment

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,7 +29,7 @@ const { version } = require('../package.json');
 
 const DEBUG = process.argv.includes('--check-isolation');
 
-// Interpolates two RGB colours across the characters of a string using ANSI true-colour codes.
+// Interpolates two RGB colors across the characters of a string using ANSI true-color codes.
 function gradient(text, [r1, g1, b1], [r2, g2, b2]) {
   const len = text.length;
   return text.split('').map((ch, i) => {


### PR DESCRIPTION
## Summary

- Replaces `colours` → `colors` and `colour` → `color` in the `gradient()` comment in `bin/cli.js` (line 32)
- Resolves two cSpell unknown-word diagnostics; no behaviour change

Closes #46

## Test plan

- [ ] No cSpell warnings on `bin/cli.js` line 32 after this change
- [ ] `gradient()` function is untouched — banner renders identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)