### PR TITLE
feat: add Playwright MCP server as optional install in setup wizard

### DIFF
--- a/__tests__/write-devcontainer.test.js
+++ b/__tests__/write-devcontainer.test.js
@@ -208,6 +208,25 @@ describe('writeDevContainer', () => {
     }
   });
 
+  it('registers Playwright MCP only when opted in and cliName is claude', () => {
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(TEST_DIR);
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude', { playwrightMcp: true });
+      expect(readGeneratedScript('post-create.sh')).toContain('claude mcp add playwright');
+      expect(readGeneratedScript('post-create.sh')).toContain('@playwright/mcp');
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'claude');
+      expect(readGeneratedScript('post-create.sh')).not.toContain('@playwright/mcp');
+
+      writeDevContainer(BASE_CONFIG, 'Node.js', false, null, false, 'gemini', { playwrightMcp: true });
+      expect(readGeneratedScript('post-create.sh')).not.toContain('@playwright/mcp');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it('writes remoteUser matching the template base image (Node.js → node)', () => {
     const originalCwd = process.cwd();
     try {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -107,6 +107,12 @@ async function main() {
     wantsSubagents = subagentsAnswer.trim().toLowerCase() === 'y';
   }
 
+  let wantsPlaywrightMcp = false;
+  if (cliName === 'claude') {
+    const playwrightAnswer = await ask('Install Playwright MCP server? [y/N]: ');
+    wantsPlaywrightMcp = playwrightAnswer.trim().toLowerCase() === 'y';
+  }
+
   // Template selection uses raw keypress mode and closes rl — must come after all ask() calls.
   let template = null;
   if (wantsIsolation) {
@@ -115,7 +121,7 @@ async function main() {
     rl.close();
   }
 
-  const tools = { caveman: wantsCaveman, subagents: wantsSubagents };
+  const tools = { caveman: wantsCaveman, subagents: wantsSubagents, playwrightMcp: wantsPlaywrightMcp };
 
   if (!wantsIsolation && !wantsGitHub) {
     console.log('\n  ⚠️  Proceeding without isolation. Be careful.\n');

--- a/bin/lib/write-devcontainer.js
+++ b/bin/lib/write-devcontainer.js
@@ -41,6 +41,10 @@ const CAVEMAN_INSTALL_CLAUDE =
 const SUBAGENTS_CLONE =
   '[ -d "$HOME/.claude/agents/awesome-subagents" ] || (mkdir -p "$HOME/.claude/agents" && git clone --depth=1 https://github.com/VoltAgent/awesome-claude-code-subagents "$HOME/.claude/agents/awesome-subagents")';
 
+// Guarded so a rebuilt volume skips re-registration if already present.
+const PLAYWRIGHT_MCP_INSTALL =
+  'claude mcp get playwright 2>/dev/null || claude mcp add playwright -- npx @playwright/mcp@latest';
+
 const ISOLATION_VSCODE_SETTINGS = {
   'git.terminalAuthentication': false,
   'github.gitAuthentication': false,
@@ -99,7 +103,7 @@ function _projectSlug() {
  * Build the content of .devcontainer/post-create.sh.
  * Each step is a separate line with a comment explaining why it exists.
  */
-function _buildPostCreateScript({ cliInstall, fixOwnership, rtkInstall, rtkInit, caveman, subagents, credCleanup }) {
+function _buildPostCreateScript({ cliInstall, fixOwnership, rtkInstall, rtkInit, caveman, subagents, playwrightMcp, credCleanup }) {
   const sections = [
     [
       '#!/usr/bin/env bash',
@@ -146,6 +150,13 @@ function _buildPostCreateScript({ cliInstall, fixOwnership, rtkInstall, rtkInit,
     ]);
   }
 
+  if (playwrightMcp) {
+    sections.push([
+      '# Register Playwright MCP server with Claude Code (guarded so a rebuilt volume skips re-registration)',
+      playwrightMcp,
+    ]);
+  }
+
   if (credCleanup) {
     sections.push([
       '# Remove the VS Code credential helper injected at container build time',
@@ -188,8 +199,9 @@ function _buildPostStartScript() {
  * @param {string|null} _tokenPath   - Unused; kept for backward compatibility.
  * @param {string}  cliName          - The AI CLI selected by the user (e.g. 'claude').
  * @param {object}  [tools]          - Optional tool opt-ins.
- * @param {boolean} [tools.caveman]  - Install the Caveman debugging plugin.
- * @param {boolean} [tools.subagents] - Clone the awesome-claude-code-subagents list.
+ * @param {boolean} [tools.caveman]       - Install the Caveman debugging plugin.
+ * @param {boolean} [tools.subagents]     - Clone the awesome-claude-code-subagents list.
+ * @param {boolean} [tools.playwrightMcp] - Register the Playwright MCP server with Claude Code.
  */
 export function writeDevContainer(config, templateName, setupGitHub = false, _tokenPath = null, _debug = false, cliName = 'claude', tools = {}) {
   const devcontainerDir = path.resolve(process.cwd(), '.devcontainer');
@@ -269,6 +281,7 @@ export function writeDevContainer(config, templateName, setupGitHub = false, _to
     rtkInit: RTK_INIT_BY_CLI[cliName] ?? RTK_INIT_BY_CLI.claude,
     caveman: (tools.caveman && cliName === 'claude') ? CAVEMAN_INSTALL_CLAUDE : null,
     subagents: (tools.subagents && cliName === 'claude') ? SUBAGENTS_CLONE : null,
+    playwrightMcp: (tools.playwrightMcp && cliName === 'claude') ? PLAYWRIGHT_MCP_INSTALL : null,
     credCleanup: useGitHub ? 'git config --global --unset-all credential.helper || true' : null,
   });
 


### PR DESCRIPTION
## Summary

- Adds **"Install Playwright MCP server? [y/N]:"** prompt to the CLI wizard (Claude-only, after Caveman / subagents prompts)
- When opted in, `post-create.sh` runs: `claude mcp get playwright 2>/dev/null || claude mcp add playwright -- npx @playwright/mcp@latest` — guarded so a rebuilt container volume skips re-registration
- Skipped entirely for non-Claude CLIs (Gemini, Codex, OpenCode)

Closes #48

## Test plan

- [ ] Run `npx ralph-workflow`, answer `y` to Playwright MCP — confirm `post-create.sh` contains `claude mcp add playwright`
- [ ] Answer `n` — confirm `post-create.sh` has no Playwright MCP entry
- [ ] Select a non-Claude CLI — confirm prompt is not shown and output is clean
- [ ] New vitest case `registers Playwright MCP only when opted in and cliName is claude` covers all three scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)