### PR TITLE
Improve setup CLI and per-CLI Ralph templates

### DIFF
--- a/__tests__/scaffold.test.js
+++ b/__tests__/scaffold.test.js
@@ -1,18 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { execFileSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
-const mockQuestion = vi.fn();
-const mockClose = vi.fn();
-vi.mock("readline", () => ({
-  default: {
-    createInterface: vi.fn(() => ({
-      question: mockQuestion,
-      close: mockClose,
-    })),
+const { mockConfirm, mockInfo, mockSpinner } = vi.hoisted(() => ({
+  mockConfirm: vi.fn(),
+  mockInfo: vi.fn(),
+  mockSpinner: {
+    start: vi.fn(),
+    stop: vi.fn(),
   },
+}));
+vi.mock("../bin/lib/ui.js", () => ({
+  confirm: mockConfirm,
+  info: mockInfo,
+  spinner: () => mockSpinner,
 }));
 
 import { scaffoldRalph } from "../bin/commands/scaffold.js";
@@ -28,7 +30,7 @@ const TEST_DIR = path.join(os.tmpdir(), ".test-scaffold-vitest");
 describe("scaffoldRalph", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockQuestion.mockImplementation((_prompt, cb) => cb("y"));
+    mockConfirm.mockResolvedValue(true);
     if (fs.existsSync(TEST_DIR)) {
       fs.rmSync(TEST_DIR, { recursive: true });
     }
@@ -219,7 +221,7 @@ describe("scaffoldRalph", () => {
     }
   });
 
-  it("should create .raplh-workflow-version file with package version", async () => {
+  it("should create .ralph-version file with package version", async () => {
     const originalCwd = process.cwd();
     try {
       process.chdir(TEST_DIR);
@@ -229,7 +231,7 @@ describe("scaffoldRalph", () => {
         TEST_DIR,
         "scripts",
         "ralph",
-        ".raplh-workflow-version",
+        ".ralph-version",
       );
       expect(fs.existsSync(versionFilePath)).toBe(true);
 
@@ -241,16 +243,15 @@ describe("scaffoldRalph", () => {
   });
 
   it("should warn and prompt when scripts/ already exists, then overwrite on confirm", async () => {
-    mockQuestion.mockImplementation((_prompt, cb) => cb("y"));
     const originalCwd = process.cwd();
     try {
       process.chdir(TEST_DIR);
       fs.mkdirSync(path.join(TEST_DIR, "scripts"), { recursive: true });
       await scaffoldRalph("claude");
 
-      expect(mockQuestion).toHaveBeenCalledWith(
-        expect.stringContaining("Proceed and overwrite?"),
-        expect.any(Function),
+      expect(mockConfirm).toHaveBeenCalledWith(
+        "Overwrite existing Ralph files in scripts?",
+        false,
       );
       expect(
         fs.existsSync(path.join(TEST_DIR, "scripts", "ralph", "ralph.sh")),
@@ -261,7 +262,7 @@ describe("scaffoldRalph", () => {
   });
 
   it("should abort scaffold when user declines overwrite prompt", async () => {
-    mockQuestion.mockImplementation((_prompt, cb) => cb("n"));
+    mockConfirm.mockResolvedValue(false);
     const originalCwd = process.cwd();
     try {
       process.chdir(TEST_DIR);
@@ -273,6 +274,10 @@ describe("scaffoldRalph", () => {
 
       await scaffoldRalph("claude");
 
+      expect(mockConfirm).toHaveBeenCalledWith(
+        "Overwrite existing Ralph files in scripts and ralph?",
+        false,
+      );
       expect(fs.existsSync(sentinelPath)).toBe(true);
       expect(
         fs.existsSync(path.join(TEST_DIR, "scripts", "ralph", "ralph.sh")),

--- a/__tests__/scaffold.test.js
+++ b/__tests__/scaffold.test.js
@@ -221,7 +221,7 @@ describe("scaffoldRalph", () => {
     }
   });
 
-  it("should create .ralph-version file with package version", async () => {
+  it("should create .ralph-workflow-version file with package version", async () => {
     const originalCwd = process.cwd();
     try {
       process.chdir(TEST_DIR);
@@ -231,7 +231,7 @@ describe("scaffoldRalph", () => {
         TEST_DIR,
         "scripts",
         "ralph",
-        ".ralph-version",
+        ".ralph-workflow-version",
       );
       expect(fs.existsSync(versionFilePath)).toBe(true);
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,7 +17,7 @@
  */
 
 import { createRequire } from 'module';
-import { rl, ask, wizardBanner, stage, step, note, success } from './lib/ui.js';
+import { intro, outro, info, note, confirm, select } from './lib/ui.js';
 import { selectTemplate } from './commands/devcontainer.js';
 import { setupGitHubAccess } from './commands/github-access.js';
 import { writeDevContainer } from './lib/write-devcontainer.js';
@@ -30,66 +30,51 @@ const { version } = require('../package.json');
 const DEBUG = process.argv.includes('--check-isolation');
 
 async function main() {
-  wizardBanner(`ralph-workflow v${version}`, 4, 3);
+  intro(version);
 
   const cliKeys = Object.keys(CLI_MAP);
-  stage(1, 4, 'Choose your AI coding CLI', 3);
-  note(`Available: ${cliKeys.join(', ')}. Claude is the default.`);
-  const cliAnswer = await ask('  CLI [claude]: ');
-  const cliName = cliAnswer.trim().toLowerCase() || 'claude';
+  const cliName = await select('Choose your AI coding CLI', cliKeys.map(name => ({
+    value: name,
+    label: CLI_MAP[name].label ?? name,
+    hint: name === 'claude' ? 'Recommended default' : undefined,
+  })));
 
-  if (!CLI_MAP[cliName]) {
-    console.error('Unknown CLI: ' + cliName + '. Supported: ' + cliKeys.join(', '));
-    rl.close();
-    process.exit(1);
-  }
+  note(
+    'Ralph runs with elevated permissions and can change files without asking. A Dev Container keeps its access isolated from the rest of your machine.',
+    'Workspace isolation'
+  );
+  const wantsIsolation = await confirm('Set up a VS Code Dev Container?', true);
 
-  stage(2, 4, 'Protect your workspace', 2);
-  step('Ralph runs with elevated permissions and can change files without asking.');
-  step('A Dev Container keeps that access isolated from the rest of your machine.');
-
-  const isolateAnswer = await ask('  Set up a VS Code Dev Container? [Y/n]: ');
-  const wantsIsolation = isolateAnswer.trim().toLowerCase() !== 'n';
-
-  stage(3, 4, 'Connect GitHub (optional)', 1);
-  note('Creates a private repository, then opens a pre-scoped token setup link.');
-  const githubAnswer = await ask('  Set up GitHub with an isolated token? [Y/n]: ');
-  const wantsGitHub = githubAnswer.trim().toLowerCase() !== 'n';
+  note(
+    'Creates a private repository, then guides you through creating a project-scoped GitHub token.',
+    'GitHub isolation'
+  );
+  const wantsGitHub = await confirm('Set up GitHub with an isolated token?', true);
 
   // Caveman and the awesome-subagents list are Claude-specific — skip their
   // prompts for other CLIs so the flow stays short.
   let wantsCaveman = false;
   let wantsSubagents = false;
   if (cliName === 'claude') {
-    console.log('');
-    step('Optional Claude additions');
-    const cavemanAnswer = await ask('  Install Caveman debugging plugin? [y/N]: ');
-    wantsCaveman = cavemanAnswer.trim().toLowerCase() === 'y';
-
-    const subagentsAnswer = await ask('  Install curated subagents collection? [y/N]: ');
-    wantsSubagents = subagentsAnswer.trim().toLowerCase() === 'y';
+    wantsCaveman = await confirm('Install the Caveman debugging plugin?', false);
+    wantsSubagents = await confirm('Install the curated subagents collection?', false);
   }
 
   let wantsPlaywrightMcp = false;
   if (cliName === 'claude') {
-    const playwrightAnswer = await ask('  Install Playwright MCP server? [y/N]: ');
-    wantsPlaywrightMcp = playwrightAnswer.trim().toLowerCase() === 'y';
+    wantsPlaywrightMcp = await confirm('Install the Playwright MCP server?', false);
   }
 
   // Template selection uses raw keypress mode and closes rl — must come after all ask() calls.
   let template = null;
   if (wantsIsolation) {
-    stage(4, 4, 'Choose a Dev Container', 0);
     template = await selectTemplate();
-  } else {
-    rl.close();
-    stage(4, 4, 'Create your Ralph workflow', 0);
   }
 
   const tools = { caveman: wantsCaveman, subagents: wantsSubagents, playwrightMcp: wantsPlaywrightMcp };
 
   if (!wantsIsolation && !wantsGitHub) {
-    console.log('\n  ⚠ Proceeding without isolation. Work only in a project you can safely change.\n');
+    info('Proceeding without isolation. Work only in a project you can safely change.');
   } else if (wantsGitHub) {
     await setupGitHubAccess();
     if (wantsIsolation) {
@@ -100,15 +85,7 @@ async function main() {
   }
 
   await scaffoldRalph(cliName);
-  success('Your Ralph workflow is ready.');
-  step(`AI coding CLI: ${cliName}`);
-  step(wantsIsolation
-    ? `Dev Container: ${template.name}`
-    : 'Dev Container: skipped');
-  step(wantsGitHub
-    ? 'GitHub isolation: configured'
-    : 'GitHub isolation: skipped');
-  note('Next: read scripts/ralph/ralph-usage-guide.md, then run scripts/ralph/ralph.sh.');
+  outro(`Ralph workflow is ready — ${cliName}${wantsIsolation ? ` in ${template.name}` : ''}.\nRead scripts/ralph/ralph-usage-guide.md to get started.`);
 }
 
 main();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,7 +17,7 @@
  */
 
 import { createRequire } from 'module';
-import { rl, ask } from './lib/ui.js';
+import { rl, ask, wizardBanner, stage, step, note, success } from './lib/ui.js';
 import { selectTemplate } from './commands/devcontainer.js';
 import { setupGitHubAccess } from './commands/github-access.js';
 import { writeDevContainer } from './lib/write-devcontainer.js';
@@ -29,54 +29,13 @@ const { version } = require('../package.json');
 
 const DEBUG = process.argv.includes('--check-isolation');
 
-// Interpolates two RGB colors across the characters of a string using ANSI true-color codes.
-function gradient(text, [r1, g1, b1], [r2, g2, b2]) {
-  const len = text.length;
-  return text.split('').map((ch, i) => {
-    const t = len > 1 ? i / (len - 1) : 0;
-    const r = Math.round(r1 + (r2 - r1) * t);
-    const g = Math.round(g1 + (g2 - g1) * t);
-    const b = Math.round(b1 + (b2 - b1) * t);
-    return `\x1b[38;2;${r};${g};${b}m${ch}`;
-  }).join('') + '\x1b[0m';
-}
-
-function printBanner() {
-  const name = 'ralph-workflow';
-  const ver  = `v${version}`;
-  const sub  = 'autonomous AI coding loop';
-
-  // Use plain strings to measure visible widths (ANSI codes are zero-width)
-  const plain1 = `  ✦ ${name}  ${ver}  `;
-  const plain2 = `  ${sub}  `;
-  const w   = Math.max(plain1.length, plain2.length);
-  const bar = '─'.repeat(w);
-
-  const gName = gradient(name, [200, 160, 255], [100, 40, 180]);
-  const gVer  = gradient(ver,  [180, 130, 240], [120, 60, 200]);
-  const dim   = '\x1b[2m';
-  const reset = '\x1b[0m';
-
-  // Build rows with ANSI content, padded to exact visible width
-  const row1 = `  ✦ ${gName}  ${gVer}  ` + ' '.repeat(w - plain1.length);
-  const row2 = plain2 + ' '.repeat(w - plain2.length);
-
-  console.log('');
-  console.log(`  ${dim}╭${bar}╮${reset}`);
-  console.log(`  ${dim}│${reset}${row1}${dim}│${reset}`);
-  console.log(`  ${dim}│${reset}${row2}${dim}│${reset}`);
-  console.log(`  ${dim}╰${bar}╯${reset}`);
-  console.log('');
-}
-
 async function main() {
-  printBanner();
+  wizardBanner(`ralph-workflow v${version}`, 4, 3);
 
   const cliKeys = Object.keys(CLI_MAP);
-  const cliList = cliKeys.map(keyItem => keyItem).join(', ');
-
-  console.log('\nSupported CLIs: ' + cliList);
-  const cliAnswer = await ask('Which AI coding CLI you want to use for Ralph? (empty for default "claude"): ');
+  stage(1, 4, 'Choose your AI coding CLI', 3);
+  note(`Available: ${cliKeys.join(', ')}. Claude is the default.`);
+  const cliAnswer = await ask('  CLI [claude]: ');
   const cliName = cliAnswer.trim().toLowerCase() || 'claude';
 
   if (!CLI_MAP[cliName]) {
@@ -85,14 +44,16 @@ async function main() {
     process.exit(1);
   }
 
-  console.log('\n   Ralph operates with elevated permissions and proceeds without confirmations (--dangerously-skip-permissions).');
-  console.log('   Risks of hallucinations and prompt injections could result in accidental file deletion, exposure of SSH keys/credentials');
-  console.log('   and corruption of other local projects. Isolation is recommended\n');
+  stage(2, 4, 'Protect your workspace', 2);
+  step('Ralph runs with elevated permissions and can change files without asking.');
+  step('A Dev Container keeps that access isolated from the rest of your machine.');
 
-  const isolateAnswer = await ask('Set up VS Code Dev Container for isolation? [Y/n]: ');
+  const isolateAnswer = await ask('  Set up a VS Code Dev Container? [Y/n]: ');
   const wantsIsolation = isolateAnswer.trim().toLowerCase() !== 'n';
 
-  const githubAnswer = await ask('Set up GitHub repository with isolated PAT token? [Y/n]: ');
+  stage(3, 4, 'Connect GitHub (optional)', 1);
+  note('Creates a private repository, then opens a pre-scoped token setup link.');
+  const githubAnswer = await ask('  Set up GitHub with an isolated token? [Y/n]: ');
   const wantsGitHub = githubAnswer.trim().toLowerCase() !== 'n';
 
   // Caveman and the awesome-subagents list are Claude-specific — skip their
@@ -100,31 +61,35 @@ async function main() {
   let wantsCaveman = false;
   let wantsSubagents = false;
   if (cliName === 'claude') {
-    const cavemanAnswer = await ask('Install Caveman debugging plugin? [y/N]: ');
+    console.log('');
+    step('Optional Claude additions');
+    const cavemanAnswer = await ask('  Install Caveman debugging plugin? [y/N]: ');
     wantsCaveman = cavemanAnswer.trim().toLowerCase() === 'y';
 
-    const subagentsAnswer = await ask('Install curated awesome-claude-code-subagents collection? [y/N]: ');
+    const subagentsAnswer = await ask('  Install curated subagents collection? [y/N]: ');
     wantsSubagents = subagentsAnswer.trim().toLowerCase() === 'y';
   }
 
   let wantsPlaywrightMcp = false;
   if (cliName === 'claude') {
-    const playwrightAnswer = await ask('Install Playwright MCP server? [y/N]: ');
+    const playwrightAnswer = await ask('  Install Playwright MCP server? [y/N]: ');
     wantsPlaywrightMcp = playwrightAnswer.trim().toLowerCase() === 'y';
   }
 
   // Template selection uses raw keypress mode and closes rl — must come after all ask() calls.
   let template = null;
   if (wantsIsolation) {
+    stage(4, 4, 'Choose a Dev Container', 0);
     template = await selectTemplate();
   } else {
     rl.close();
+    stage(4, 4, 'Create your Ralph workflow', 0);
   }
 
   const tools = { caveman: wantsCaveman, subagents: wantsSubagents, playwrightMcp: wantsPlaywrightMcp };
 
   if (!wantsIsolation && !wantsGitHub) {
-    console.log('\n  ⚠️  Proceeding without isolation. Be careful.\n');
+    console.log('\n  ⚠ Proceeding without isolation. Work only in a project you can safely change.\n');
   } else if (wantsGitHub) {
     await setupGitHubAccess();
     if (wantsIsolation) {
@@ -135,6 +100,15 @@ async function main() {
   }
 
   await scaffoldRalph(cliName);
+  success('Your Ralph workflow is ready.');
+  step(`AI coding CLI: ${cliName}`);
+  step(wantsIsolation
+    ? `Dev Container: ${template.name}`
+    : 'Dev Container: skipped');
+  step(wantsGitHub
+    ? 'GitHub isolation: configured'
+    : 'GitHub isolation: skipped');
+  note('Next: read scripts/ralph/ralph-usage-guide.md, then run scripts/ralph/ralph.sh.');
 }
 
 main();

--- a/bin/commands/devcontainer.js
+++ b/bin/commands/devcontainer.js
@@ -14,7 +14,10 @@ import { TEMPLATES } from '../lib/devcontainer-templates.js';
  * @returns {Promise<object>} The chosen template object.
  */
 export async function selectTemplate() {
-  console.log('\nSelect a Dev Container template (use arrow keys, Enter to confirm):\n');
-  const idx = await selectMenu(TEMPLATES.map(t => t.label));
+  console.log('\n  Choose the environment your agent will work inside.');
+  console.log('  Use ↑/↓ and Enter to select.\n');
+  const idx = await selectMenu(TEMPLATES.map(t => ({
+    label: `${t.label} — ${t.description}`,
+  })));
   return TEMPLATES[idx];
 }

--- a/bin/commands/devcontainer.js
+++ b/bin/commands/devcontainer.js
@@ -5,7 +5,7 @@
  * Orchestration (GitHub setup, writeDevContainer) is handled by cli.js.
  */
 
-import { selectMenu } from '../lib/ui.js';
+import { select } from '../lib/ui.js';
 import { TEMPLATES } from '../lib/devcontainer-templates.js';
 
 /**
@@ -14,10 +14,10 @@ import { TEMPLATES } from '../lib/devcontainer-templates.js';
  * @returns {Promise<object>} The chosen template object.
  */
 export async function selectTemplate() {
-  console.log('\n  Choose the environment your agent will work inside.');
-  console.log('  Use ↑/↓ and Enter to select.\n');
-  const idx = await selectMenu(TEMPLATES.map(t => ({
-    label: `${t.label} — ${t.description}`,
+  const name = await select('Choose a Dev Container', TEMPLATES.map(t => ({
+    value: t.name,
+    label: t.label,
+    hint: t.description,
   })));
-  return TEMPLATES[idx];
+  return TEMPLATES.find(t => t.name === name);
 }

--- a/bin/commands/github-access.js
+++ b/bin/commands/github-access.js
@@ -13,8 +13,8 @@
 
 import fs from 'fs';
 import path from 'path';
-import readline from 'readline';
 import { execSync } from 'child_process';
+import { confirm, info, note, password, spinner } from '../lib/ui.js';
 
 /**
  * Git repository, GitHub repo creation, and PAT token setup flow.
@@ -22,21 +22,17 @@ import { execSync } from 'child_process';
  */
 export async function setupGitHubAccess() {
   const projectName = path.basename(process.cwd());
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  const ask = (q) => new Promise(resolve => rl.question(q, resolve));
-
-  console.log(`\nSetting up GitHub isolation for project: ${projectName}`);
+  info(`Setting up GitHub isolation for ${projectName}`);
 
   _ensureGitRepo();
   _ensureInitialCommit(projectName);
 
-  const userName = await _getGitHubUsername(ask);
+  const userName = await _getGitHubUsername();
 
-  console.log('Note: a private GitHub repository will be created automatically using the gh CLI.');
-  await _createGitHubRepo(projectName, userName, ask);
+  note('A private GitHub repository will be created automatically with the gh CLI.', 'GitHub repository');
+  await _createGitHubRepo(projectName, userName);
 
-  const token = await _promptForPAT(ask, projectName, userName);
-  rl.close();
+  const token = await _promptForPAT(projectName, userName);
 
   _storeToken(token);
 }
@@ -46,7 +42,7 @@ function _ensureGitRepo() {
   try {
     execSync('git rev-parse --git-dir', { stdio: 'pipe' });
   } catch {
-    console.log('Initializing git repository...');
+    info('Initializing git repository');
     execSync('git init -b main 2>/dev/null || git init 2>/dev/null', { stdio: 'inherit' });
   }
 }
@@ -78,7 +74,7 @@ function _ensureInitialCommit(projectName) {
     }
   }
 
-  console.log('Creating initial commit so the new GitHub repo has something to push...');
+  info('Creating an initial commit so the new repository has something to push');
   execSync('git add -A', { stdio: 'inherit' });
   execSync('git commit -m "chore: initial commit"', { stdio: 'inherit' });
 }
@@ -86,19 +82,16 @@ function _ensureInitialCommit(projectName) {
 /**
  * Resolve the authenticated GitHub username via the gh CLI.
  * Retries on failure until the user succeeds or declines.
- * @param {function} ask
  * @returns {Promise<string>}
  */
-async function _getGitHubUsername(ask) {
+async function _getGitHubUsername() {
   while (true) {
     try {
       return execSync('gh api user -q .login', { encoding: 'utf8', stdio: 'pipe' }).trim();
     } catch (err) {
       const stderr = (err.stderr || '').toString().trim();
-      console.error(`\nFailed to reach GitHub: ${stderr || 'unknown error'}`);
-      console.error('Ensure gh is authenticated (gh auth login) and you have internet access.');
-      const answer = await ask('Would you like to retry? (y/n): ');
-      if (answer.trim().toLowerCase() !== 'y') {
+      note(`Failed to reach GitHub: ${stderr || 'unknown error'}\n\nRun \`gh auth login\`, then try again.`, 'GitHub needs attention');
+      if (!await confirm('Retry GitHub connection?', false)) {
         console.error('\nCannot continue without GitHub access. Run `gh auth login` and try again.');
         process.exit(1);
       }
@@ -111,32 +104,34 @@ async function _getGitHubUsername(ask) {
  * Retries on failure until the user succeeds or declines.
  * @param {string}   projectName
  * @param {string}   userName
- * @param {function} ask
  */
-async function _createGitHubRepo(projectName, userName, ask) {
-  console.log('Creating private GitHub repository...');
+async function _createGitHubRepo(projectName, userName) {
+  const progress = spinner();
+  progress.start('Creating private GitHub repository');
   while (true) {
     try {
       execSync(
         `gh repo create "${projectName}" --private --source=. --push`,
         { stdio: 'pipe' }
       );
+      progress.stop('Private GitHub repository created');
       break;
     } catch (err) {
       const stderr = (err.stderr || '').toString();
       if (stderr.toLowerCase().includes('already exists')) {
-        console.log('Repository already exists, continuing...');
+        progress.stop('Private GitHub repository already exists');
         break;
       }
-      console.error(`\nFailed to create GitHub repository: ${stderr.trim() || 'unknown error'}`);
-      const answer = await ask('Would you like to retry? (y/n): ');
-      if (answer.trim().toLowerCase() !== 'y') {
+      progress.stop('Could not create GitHub repository');
+      note(stderr.trim() || 'Unknown error', 'GitHub repository error');
+      if (!await confirm('Retry repository creation?', false)) {
         console.error('\nCannot continue without a GitHub repository. Before re-running, check:');
         console.error('  • gh auth status  — ensure you are authenticated');
         console.error('  • The repository name is not already taken under a different account');
         console.error('  • You have permission to create repositories on this account');
         process.exit(1);
       }
+      progress.start('Creating private GitHub repository');
     }
   }
 
@@ -149,33 +144,25 @@ async function _createGitHubRepo(projectName, userName, ask) {
 
 /**
  * Print PAT creation instructions and read the token from stdin.
- * @param {function} ask
  * @param {string}   projectName
  * @param {string}   userName
  * @returns {Promise<string>} The raw token string.
  */
-async function _promptForPAT(ask, projectName, userName) {
+async function _promptForPAT(projectName, userName) {
   const patUrl =
     `https://github.com/settings/personal-access-tokens/new` +
     `?name=Ralph-${projectName}&target_name=${userName}&expires_in=1` +
     `&contents=write&pull_requests=write&issues=write&notifications=read&metadata=read`;
 
-  console.log("\n── Create Ralph's GitHub Token ───────────────────────────────────────");
-  console.log('Open this URL in your browser (name and permissions are pre-filled):');
-  console.log('');
-  console.log(patUrl);
-  console.log('');
-  console.log('IMPORTANT: Under "Repository access", select "Only select repositories"');
-  console.log(`           then choose: ${projectName}`);
-  console.log('');
-  console.log('Set an expiration, click Generate, then paste the token below.');
+  note(
+    `Under “Repository access”, choose “Only select repositories”, then select ${projectName}. Set an expiration, generate the token, and paste it below.`,
+    "Create Ralph's GitHub token"
+  );
+  // Do not put this URL inside p.note(): its box renderer hard-wraps long
+  // lines, which makes the query string awkward to copy from the terminal.
+  console.log(`\n${patUrl}\n`);
 
-  const token = await ask('Token: ');
-
-  if (!token.trim()) {
-    console.error('Error: no token provided. Aborting.');
-    process.exit(1);
-  }
+  const token = await password('Paste the GitHub token');
 
   return token.trim();
 }
@@ -202,7 +189,7 @@ function _storeToken(token) {
 
   _ensureGitignore('.ralph/');
 
-  console.log(`Token stored: ${tokenPath}`);
+  info(`GitHub token stored at ${tokenPath}`);
 }
 
 /**

--- a/bin/commands/scaffold.js
+++ b/bin/commands/scaffold.js
@@ -85,7 +85,7 @@ export async function scaffoldRalph(cliName = 'claude') {
     fs.chmodSync(ralphShPath, 0o755);
 
     // Record the scaffolding version so users can tell which release was used
-    const versionFilePath = path.join(targetRalphDir, '.ralph-version');
+    const versionFilePath = path.join(targetRalphDir, '.ralph-workflow-version');
     fs.writeFileSync(versionFilePath, 'ralph-workflow@' + RALPH_VERSION + '\n', 'utf-8');
 
     progress.stop("Created 'scripts' directory");

--- a/bin/commands/scaffold.js
+++ b/bin/commands/scaffold.js
@@ -7,9 +7,9 @@
 
 import fs from 'fs';
 import path from 'path';
-import readline from 'readline';
 import { fileURLToPath } from 'url';
 import CLI_MAP from '../lib/cli-map.js';
+import { confirm, info, spinner } from '../lib/ui.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -38,18 +38,18 @@ export async function scaffoldRalph(cliName = 'claude') {
 
   const existingDirs = [targetScriptsDir, targetRalphDir].filter(d => fs.existsSync(d));
   if (existingDirs.length > 0) {
-    console.warn('\n  ⚠ Existing Ralph files will be overwritten:');
-    existingDirs.forEach(d => console.warn('  ' + d));
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    const answer = await new Promise(resolve => rl.question('\n  Proceed and overwrite? [y/N]: ', resolve));
-    rl.close();
-    if (answer.trim().toLowerCase() !== 'y') {
-      console.log('  Setup cancelled. No files were changed.');
+    const shouldOverwrite = await confirm(
+      `Overwrite existing Ralph files in ${existingDirs.map(dir => path.basename(dir)).join(' and ')}?`,
+      false
+    );
+    if (!shouldOverwrite) {
+      info('Existing Ralph files were left unchanged.');
       return;
     }
   }
 
-  console.log('\n  Creating Ralph workflow files...');
+  const progress = spinner();
+  progress.start('Creating Ralph workflow files');
 
   if (!fs.existsSync(SOURCE_DIR)) {
     console.error('Error: template directory not found at ' + SOURCE_DIR);
@@ -88,8 +88,9 @@ export async function scaffoldRalph(cliName = 'claude') {
     const versionFilePath = path.join(targetRalphDir, '.raplh-workflow-version');
     fs.writeFileSync(versionFilePath, 'ralph-workflow@' + RALPH_VERSION + '\n', 'utf-8');
 
-    console.log("  ✓ Created 'scripts' directory");
+    progress.stop("Created 'scripts' directory");
   } catch (err) {
+    progress.stop('Could not create Ralph workflow files');
     console.error('Error scaffolding files:', err);
     process.exit(1);
   }

--- a/bin/commands/scaffold.js
+++ b/bin/commands/scaffold.js
@@ -38,18 +38,18 @@ export async function scaffoldRalph(cliName = 'claude') {
 
   const existingDirs = [targetScriptsDir, targetRalphDir].filter(d => fs.existsSync(d));
   if (existingDirs.length > 0) {
-    console.warn('\nWarning: the following director' + (existingDirs.length > 1 ? 'ies' : 'y') + ' already exist and will be overwritten:');
+    console.warn('\n  ⚠ Existing Ralph files will be overwritten:');
     existingDirs.forEach(d => console.warn('  ' + d));
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    const answer = await new Promise(resolve => rl.question('\nProceed and overwrite? [y/N]: ', resolve));
+    const answer = await new Promise(resolve => rl.question('\n  Proceed and overwrite? [y/N]: ', resolve));
     rl.close();
     if (answer.trim().toLowerCase() !== 'y') {
-      console.log('Scaffold cancelled. No files were changed.');
+      console.log('  Setup cancelled. No files were changed.');
       return;
     }
   }
 
-  console.log('Scaffolding scripts directory...');
+  console.log('\n  Creating Ralph workflow files...');
 
   if (!fs.existsSync(SOURCE_DIR)) {
     console.error('Error: template directory not found at ' + SOURCE_DIR);
@@ -88,9 +88,7 @@ export async function scaffoldRalph(cliName = 'claude') {
     const versionFilePath = path.join(targetRalphDir, '.raplh-workflow-version');
     fs.writeFileSync(versionFilePath, 'ralph-workflow@' + RALPH_VERSION + '\n', 'utf-8');
 
-    console.log("'scripts' directory has been created");
-    console.log('\nYou can now use the Ralph scripts in your workflow.');
-    console.log('Read scripts/ralph/ralph-usage-guide.md for more info.');
+    console.log("  ✓ Created 'scripts' directory");
   } catch (err) {
     console.error('Error scaffolding files:', err);
     process.exit(1);

--- a/bin/commands/scaffold.js
+++ b/bin/commands/scaffold.js
@@ -85,7 +85,7 @@ export async function scaffoldRalph(cliName = 'claude') {
     fs.chmodSync(ralphShPath, 0o755);
 
     // Record the scaffolding version so users can tell which release was used
-    const versionFilePath = path.join(targetRalphDir, '.raplh-workflow-version');
+    const versionFilePath = path.join(targetRalphDir, '.ralph-version');
     fs.writeFileSync(versionFilePath, 'ralph-workflow@' + RALPH_VERSION + '\n', 'utf-8');
 
     progress.stop("Created 'scripts' directory");

--- a/bin/lib/devcontainer-templates.js
+++ b/bin/lib/devcontainer-templates.js
@@ -2,20 +2,20 @@
  * Dev Container template definitions.
  *
  * Each template provides a base `config` object that is later merged with
- * isolation settings in `write-devcontainer.js`. The `label` strings are
- * shown verbatim in the interactive selection menu.
+ * isolation settings in `write-devcontainer.js`.
  */
 
 const claudeInstall = 'npm install -g @anthropic-ai/claude-code';
 const remoteEnv = { ANTHROPIC_API_KEY: '${localEnv:ANTHROPIC_API_KEY}' };
 
-/** @typedef {{ name: string, label: string, config: object }} Template */
+/** @typedef {{ name: string, label: string, description: string, config: object }} Template */
 
 /** @type {Template[]} */
 export const TEMPLATES = [
   {
     name: 'Node.js',
-    label: 'Node              - Node.js projects',
+    label: 'Node.js',
+    description: 'Node.js projects with ESLint',
     config: {
       name: 'Node.js',
       image: 'mcr.microsoft.com/devcontainers/javascript-node:24',
@@ -26,7 +26,8 @@ export const TEMPLATES = [
   },
   {
     name: 'Python',
-    label: 'Python            - Python projects',
+    label: 'Python',
+    description: 'Python projects with Node available for AI tooling',
     config: {
       name: 'Python',
       image: 'mcr.microsoft.com/devcontainers/python:3.11',
@@ -38,7 +39,8 @@ export const TEMPLATES = [
   },
   {
     name: 'Python + Node',
-    label: 'Python + Node     - General automation work',
+    label: 'Python + Node',
+    description: 'General automation and full-stack work',
     config: {
       name: 'Python + Node',
       image: 'mcr.microsoft.com/devcontainers/python:3.11',
@@ -50,7 +52,8 @@ export const TEMPLATES = [
   },
   {
     name: 'Minimal Ubuntu',
-    label: 'Minimal Ubuntu    - Lightest footprint',
+    label: 'Minimal Ubuntu',
+    description: 'The lightest footprint',
     config: {
       name: 'Minimal Ubuntu',
       image: 'mcr.microsoft.com/devcontainers/base:ubuntu',
@@ -61,7 +64,8 @@ export const TEMPLATES = [
   },
   {
     name: 'Full Dev Environment',
-    label: 'Full Dev Environment - Comprehensive tooling',
+    label: 'Full Dev Environment',
+    description: 'Node, Python, Git, and common VS Code extensions',
     config: {
       name: 'Full Dev Environment',
       image: 'mcr.microsoft.com/devcontainers/base:ubuntu',

--- a/bin/lib/ui.js
+++ b/bin/lib/ui.js
@@ -21,7 +21,7 @@ const RALPH_WORDMARK = [
 
 function unwrap(value) {
   if (p.isCancel(value)) {
-    p.cancel('Setup cancelled. No files were changed.');
+    p.cancel('Setup cancelled.');
     process.exit(0);
   }
   return value;

--- a/bin/lib/ui.js
+++ b/bin/lib/ui.js
@@ -1,120 +1,67 @@
 /**
- * Terminal UI helpers — readline prompt and interactive arrow-key menu.
+ * Shared interactive UI, powered by Clack.
+ *
+ * Clack gives every prompt the connected timeline, coloured status glyphs,
+ * cancellation handling, and accessible non-TTY fallback used by skills.sh.
  */
 
-import readline from 'readline';
-
-export const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+import * as p from '@clack/prompts';
 
 const isTTY = Boolean(process.stdout.isTTY);
 const paint = (code, text) => isTTY ? `\x1b[${code}m${text}\x1b[0m` : text;
 
-/** Clear only interactive terminals, preserving useful logs in pipes and CI. */
-export function clear() {
-  if (isTTY) process.stdout.write('\x1b[2J\x1b[3J\x1b[H');
+const RALPH_WORDMARK = [
+  '██████╗  █████╗ ██╗     ██████╗ ██╗  ██╗',
+  '██╔══██╗██╔══██╗██║     ██╔══██╗██║  ██║',
+  '██████╔╝███████║██║     ██████╔╝███████║',
+  '██╔══██╗██╔══██║██║     ██╔═══╝ ██╔══██║',
+  '██║  ██║██║  ██║███████╗██║     ██║  ██║',
+  '╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚═╝     ╚═╝  ╚═╝',
+].join('\n');
+
+function unwrap(value) {
+  if (p.isCancel(value)) {
+    p.cancel('Setup cancelled. No files were changed.');
+    process.exit(0);
+  }
+  return value;
 }
 
-/** Opening frame for a short, guided setup. */
-export function wizardBanner(title, stages, minutes) {
-  clear();
-  console.log(`\n${paint('1;36', `  ${title}`)}`);
-  console.log(`  ${paint('2', `${stages} stages · about ${minutes} minutes`)}`);
-  console.log(`\n  ${paint('2', 'Answer a few questions and we will create the Ralph workflow in this folder.')}`);
-  console.log(`  ${paint('2', 'You can stop at any time with Ctrl-C and run this command again later.')}`);
+export function intro(version) {
+  console.log('');
+  console.log(paint('38;5;141', RALPH_WORDMARK));
+  console.log('');
+  p.intro(paint('48;5;135;38;5;231;1', ` ralph-workflow v${version} `));
 }
 
-/** Print a compact, readable setup stage. Safe to use when output is piped. */
-export function stage(current, total, title, minutesLeft, detail = '') {
-  clear();
-  const remaining = minutesLeft === 1 ? '1 min left' : `~${minutesLeft} min left`;
-  console.log(`\n${paint('1;36', `  ▸ Stage ${current}/${total} · ${title}`)}  ${paint('2', `(${remaining})`)}`);
-  if (detail) console.log(`  ${paint('2', detail)}`);
+export function outro(message) {
+  p.outro(message);
 }
 
-export function step(message) {
-  console.log(`  ${paint('36', '•')} ${message}`);
+export function info(message) {
+  p.log.info(message);
 }
 
-export function note(message) {
-  console.log(`  ${paint('2', message)}`);
+export function warn(message) {
+  p.log.warn(message);
 }
 
-export function success(message) {
-  clear();
-  console.log(`\n${paint('1;32', '  ✓ Setup complete')}`);
-  console.log(`  ${message}`);
+export function note(message, title) {
+  p.note(message, title);
 }
 
-/**
- * Prompt the user for a single line of input.
- * @param {string} question - Text displayed before the cursor.
- * @returns {Promise<string>}
- */
-export function ask(question) {
-  return new Promise(resolve => rl.question(question, resolve));
+export async function select(message, options) {
+  return unwrap(await p.select({ message, options }));
 }
 
-/**
- * Display an interactive arrow-key menu and resolve with the chosen index.
- * Closes the shared `rl` interface before taking over stdin raw mode,
- * then restores normal stdin state when the user presses Enter.
- * @param {string[]} options - Menu items to display.
- * @returns {Promise<number>} Zero-based index of the selected option.
- */
-export function selectMenu(options) {
-  return new Promise((resolve) => {
-    let selected = 0;
-    const labels = options.map(option => typeof option === 'string' ? option : option.label);
+export async function confirm(message, initialValue = true) {
+  return unwrap(await p.confirm({ message, initialValue }));
+}
 
-    // Raw keypress handling only works in an interactive terminal. Keeping a
-    // numbered fallback makes the CLI usable in CI, piped shells, and tests.
-    if (!process.stdin.isTTY) {
-      rl.close();
-      console.log(labels.map((label, i) => `  ${i + 1}. ${label}`).join('\n'));
-      resolve(0);
-      return;
-    }
+export async function password(message) {
+  return unwrap(await p.password({ message, validate: value => value.trim() ? undefined : 'A token is required.' }));
+}
 
-    // Close readline — it holds stdin and blocks raw keypress events.
-    rl.close();
-
-    readline.emitKeypressEvents(process.stdin);
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-
-    function render() {
-      labels.forEach((opt, i) => {
-        const cursor = i === selected ? `${paint('36', '>')} ` : '  ';
-        const label = i === selected ? paint('1;34', opt) : opt;
-        process.stdout.write(`\r${cursor}${label}\x1b[K\n`);
-      });
-      process.stdout.write(`\x1b[${options.length}A`);
-    }
-
-    render();
-
-    function onKeypress(str, key) {
-      if (!key) return;
-
-      if (key.name === 'up') {
-        selected = (selected - 1 + options.length) % options.length;
-        render();
-      } else if (key.name === 'down') {
-        selected = (selected + 1) % options.length;
-        render();
-      } else if (key.name === 'return') {
-        process.stdin.removeListener('keypress', onKeypress);
-        process.stdin.setRawMode(false);
-        process.stdin.pause();
-        process.stdout.write(`\x1b[${labels.length}B\n`);
-        resolve(selected);
-      } else if (key.ctrl && key.name === 'c') {
-        process.stdin.setRawMode(false);
-        process.stdout.write('\n');
-        process.exit(0);
-      }
-    }
-
-    process.stdin.on('keypress', onKeypress);
-  });
+export function spinner() {
+  return p.spinner();
 }

--- a/bin/lib/ui.js
+++ b/bin/lib/ui.js
@@ -6,6 +6,45 @@ import readline from 'readline';
 
 export const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
+const isTTY = Boolean(process.stdout.isTTY);
+const paint = (code, text) => isTTY ? `\x1b[${code}m${text}\x1b[0m` : text;
+
+/** Clear only interactive terminals, preserving useful logs in pipes and CI. */
+export function clear() {
+  if (isTTY) process.stdout.write('\x1b[2J\x1b[3J\x1b[H');
+}
+
+/** Opening frame for a short, guided setup. */
+export function wizardBanner(title, stages, minutes) {
+  clear();
+  console.log(`\n${paint('1;36', `  ${title}`)}`);
+  console.log(`  ${paint('2', `${stages} stages · about ${minutes} minutes`)}`);
+  console.log(`\n  ${paint('2', 'Answer a few questions and we will create the Ralph workflow in this folder.')}`);
+  console.log(`  ${paint('2', 'You can stop at any time with Ctrl-C and run this command again later.')}`);
+}
+
+/** Print a compact, readable setup stage. Safe to use when output is piped. */
+export function stage(current, total, title, minutesLeft, detail = '') {
+  clear();
+  const remaining = minutesLeft === 1 ? '1 min left' : `~${minutesLeft} min left`;
+  console.log(`\n${paint('1;36', `  ▸ Stage ${current}/${total} · ${title}`)}  ${paint('2', `(${remaining})`)}`);
+  if (detail) console.log(`  ${paint('2', detail)}`);
+}
+
+export function step(message) {
+  console.log(`  ${paint('36', '•')} ${message}`);
+}
+
+export function note(message) {
+  console.log(`  ${paint('2', message)}`);
+}
+
+export function success(message) {
+  clear();
+  console.log(`\n${paint('1;32', '  ✓ Setup complete')}`);
+  console.log(`  ${message}`);
+}
+
 /**
  * Prompt the user for a single line of input.
  * @param {string} question - Text displayed before the cursor.
@@ -25,6 +64,16 @@ export function ask(question) {
 export function selectMenu(options) {
   return new Promise((resolve) => {
     let selected = 0;
+    const labels = options.map(option => typeof option === 'string' ? option : option.label);
+
+    // Raw keypress handling only works in an interactive terminal. Keeping a
+    // numbered fallback makes the CLI usable in CI, piped shells, and tests.
+    if (!process.stdin.isTTY) {
+      rl.close();
+      console.log(labels.map((label, i) => `  ${i + 1}. ${label}`).join('\n'));
+      resolve(0);
+      return;
+    }
 
     // Close readline — it holds stdin and blocks raw keypress events.
     rl.close();
@@ -34,9 +83,9 @@ export function selectMenu(options) {
     process.stdin.resume();
 
     function render() {
-      options.forEach((opt, i) => {
-        const cursor = i === selected ? '\x1b[36m>\x1b[0m ' : '  ';
-        const label = i === selected ? `\x1b[1;34m${opt}\x1b[0m` : opt;
+      labels.forEach((opt, i) => {
+        const cursor = i === selected ? `${paint('36', '>')} ` : '  ';
+        const label = i === selected ? paint('1;34', opt) : opt;
         process.stdout.write(`\r${cursor}${label}\x1b[K\n`);
       });
       process.stdout.write(`\x1b[${options.length}A`);
@@ -57,7 +106,7 @@ export function selectMenu(options) {
         process.stdin.removeListener('keypress', onKeypress);
         process.stdin.setRawMode(false);
         process.stdin.pause();
-        process.stdout.write(`\x1b[${options.length}B\n`);
+        process.stdout.write(`\x1b[${labels.length}B\n`);
         resolve(selected);
       } else if (key.ctrl && key.name === 'c') {
         process.stdin.setRawMode(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,40 @@
 {
   "name": "ralph-workflow",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ralph-workflow",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^1.0.0"
+      },
       "bin": {
         "ralph-workflow": "bin/cli.js"
       },
       "devDependencies": {
         "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.0.tgz",
+      "integrity": "sha512-Orf9Ltr5NeiEuVJS8Rk2XTw3IxNC2Bic3ash7GgYeA8LJ/zmSNpSQ/m5UAhe03lA6KFgklzZ5KTHs4OAMA/SAQ==",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.0.tgz",
+      "integrity": "sha512-rWPXg9UaCFqErJVQ+MecOaWsozjaxol4yjnmYcGNipAWzdaWa2x+VJmKfGq7L0APwBohQOYdHC+9RO4qRXej+A==",
+      "dependencies": {
+        "@clack/core": "1.0.0",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@emnapi/core": {
@@ -914,7 +936,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -999,6 +1020,11 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   },
   "devDependencies": {
     "vitest": "^4.1.4"
+  },
+  "dependencies": {
+    "@clack/prompts": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Replace the custom readline flow with Clack prompts, status UI, cancellation handling, and masked token entry.
- Split Ralph runner, prompt, and usage-guide files into CLI-specific templates, while keeping shared workflow files common.
- Update scaffolding to overlay the selected CLI template and cover that behavior with tests.

## Why

Each supported coding CLI needs its own runner and instructions; the setup flow also needed a clearer, more accessible interactive experience.

## Validation

- `git diff --check origin/main...HEAD`
- `node --check` on changed JavaScript modules
- `npm test` is blocked locally: Node 16.18 lacks `node:util.styleText`, required by the installed Vitest runtime.