### PR TITLE
docs: clarify Ralph task fit and proof

### DIFF
--- a/MARKETING-PLAN.md
+++ b/MARKETING-PLAN.md
@@ -1,0 +1,241 @@
+# Ralph Workflow Marketing Improvement Plan
+
+## Decision from a developer's perspective
+
+I would try Ralph Workflow for a well-scoped backlog that can run unattended: exploratory prototypes, a bounded feature slice, maintenance work, or a sequence of independently testable stories. Its meaningful advantage over a one-shot coding prompt is not that it produces code once; it gives an agent a repeatable operating loop: select the next story, retain project learnings, run checks, commit the result, and continue while I am away. Multi-CLI support and an optional isolated Dev Container make that loop more practical for developers who cannot safely grant an autonomous agent their normal machine credentials.
+
+I would not choose it for a tiny change, ambiguous product work, a codebase without dependable checks, or any task requiring frequent human product/design judgment. A one-shot agent session is quicker and cheaper to supervise in those cases. Ralph should say this plainly: it is an execution system for a prepared backlog, not a replacement for developer judgment or a promise of hands-free software delivery.
+
+## Current first impression
+
+The documentation home page is unlikely to make most developers stop reading immediately, but it does make the wrong promise first. The hero says the package “scaffold[s] everything” and foregrounds VS Code Dev Containers and isolated GitHub credentials. A developer who came to learn why they should use a Ralph loop instead of Codex/Claude in a normal terminal has to infer the product outcome from later feature cards.
+
+The safety story is a strong differentiator, but it is presented before the value story. The long simulated install transcript also exposes four optional choices, PAT creation, RTK, and a container before a reader has seen a feature successfully completed. The result is cognitive load and risk anxiety before motivation. The usage guide reinforces this by presenting setup and credential mechanics before a fast path, a concrete example, operating limits, or expected results. “How It Works” does explain the loop clearly, but it begins with security and has copy-quality issues that reduce trust. The navigation has only Home, Usage Guide, and How It Works; there is no “When to use Ralph,” demo, examples, safety model summary, or troubleshooting path.
+
+There is also a credibility issue to resolve before promotion: checked-in `docs/out/` text appears to describe an older experience (including a different feature order and token location) than `docs/app/`. Generated deployment artifacts must be rebuilt or removed from version control so published copy always matches the CLI.
+
+Critical truth gaps to fix before publishing new copy:
+
+- The home-page PAT claim is narrower than the generator's requested permissions; document the exact permissions the current setup asks for, or reduce the implementation to match the claim.
+- The wizard can initialize Git, create an initial commit, and create a private GitHub repository. Surface these state-changing effects before consent, ideally in a final confirmation and a dry-run/plan preview.
+- The product claims four CLIs, while the guide's authentication section is Claude-only and parts of the prose still say “Claude.” Add provider-specific setup and mark any unsupported behavior.
+- A Dev Container limits credential exposure; it is not an absolute “hard boundary,” and a repo/workspace agent can still alter files, consume resources, access any explicitly mounted material, and make network requests allowed by its environment.
+
+## Marketing objective
+
+Make Ralph Workflow the obvious choice for developers who already use an AI coding CLI and need to convert a clearly specified, multi-story backlog into reviewable, tested progress without manually re-prompting every task.
+
+The primary activation event is: a developer scaffolds Ralph, runs a small example or their first real backlog, and sees a committed, passing story. The product message must lead to this result before asking users to evaluate optional isolation and remote-Git setup.
+
+## Positioning
+
+### Category and promise
+
+**Category:** a safe autonomous feature-execution workflow for existing AI coding CLIs.
+
+**Core promise:** Turn a prepared feature backlog into tested, commit-by-commit progress while you are away.
+
+**Support statement:** Ralph Workflow gives Claude, Codex, Gemini, or OpenCode a repeatable loop: choose the next testable story, carry forward repository learnings, implement, verify, commit, and continue. Optional Dev Container isolation restricts autonomous access to the repository and credentials you explicitly provide.
+
+### Proposed home-page hero
+
+> **Ship a prepared feature backlog while you are away.**
+>
+> Ralph Workflow runs your AI coding CLI through small, testable stories—preserving context, running checks, and committing each completed change. Start locally, or add an isolated Dev Container when the agent needs unattended permissions.
+
+Primary CTA: **Run the 10-minute example**
+
+Secondary CTA: **See the loop in action**
+
+Keep a third, quiet link for security-minded visitors: **How isolation works**.
+
+### Message hierarchy
+
+1. Outcome: a prepared backlog becomes tested, reviewable commits.
+2. Mechanism: a durable task loop with `prd.yaml`, `progress.txt`, tests, and commits.
+3. Fit: best for several small, independently verifiable stories—not one-off or ambiguous work.
+4. Trust: inspectable files, explicit limits, commits per story, and test gates.
+5. Safety: optional container isolation and least-privilege GitHub access.
+6. Compatibility: Claude, Codex, Gemini, and OpenCode.
+
+Do not lead with “scaffold,” “Dev Container,” or `--dangerously-skip-permissions`; they explain the product but are not the reason to desire it.
+
+## Target audiences and objections
+
+| Audience | Job to be done | Likely objection | Message / proof needed |
+| --- | --- | --- | --- |
+| AI-native solo developer | Make progress on a defined side-project backlog overnight. | “Why not ask Codex/Claude once?” | Show reduced re-prompting and a sequence of independently tested commits. |
+| Senior engineer / tech lead | Delegate low-risk, well-specified maintenance or feature slices. | “Can I review and control it?” | Explain task granularity, test gates, branches/commits, iteration caps, and stop conditions. |
+| Security-conscious developer | Try autonomous coding without exposing host credentials. | “`dangerously-skip-permissions` is unacceptable.” | Lead them to a concise threat model, optional isolation setup, and explicit non-guarantees. |
+| Early adopter of a supported CLI | Reuse an existing CLI rather than adopt another agent platform. | “Will it work with my tool and repo?” | CLI compatibility matrix, prerequisites, and one verified example per supported CLI. |
+
+## Site and documentation plan
+
+### 1. Redesign the home page around the decision
+
+Replace the current feature-first, setup-heavy home page with this sequence:
+
+1. Outcome-led hero and two CTAs.
+2. A 30–60 second terminal/video/GIF proof: input stories → agent iterations → tests → git log with completed commits.
+3. “Ralph vs. a one-shot prompt” comparison focused on use cases, not claims of universal superiority.
+4. “Use Ralph when / do not use Ralph when” card.
+5. A compact three-step journey: prepare stories, run loop, review commits.
+6. Trust section: transparent files, supported CLIs, optional isolation, and explicit boundaries.
+7. Example gallery and links to the fast start, safety model, and full reference.
+
+The home-page quick start should have two paths:
+
+- **Fast local trial:** scaffold the workflow and run a toy/example backlog without remote GitHub access.
+- **Safe unattended setup:** opt into the Dev Container and scoped PAT when the agent needs remote access.
+
+This makes the lowest-risk activation path visible and treats isolation as a selectable capability, not a prerequisite to understand value.
+
+### 2. Add decision-oriented pages
+
+Create these pages and add them to navigation:
+
+- **Is Ralph right for this task?** A decision table covering story count, acceptance criteria, testability, expected supervision, cost/time expectations, and red flags.
+- **Example runs:** at least two complete, reproducible before/after examples: a greenfield mini-feature and a maintenance/refactor slice. Include input PRD, iteration cap, resulting commits, tests run, human review needed, elapsed time, and known failures/retries.
+- **Safety model:** concise threat model explaining what isolation protects, what it does not protect, why `--dangerously-skip-permissions` is used, local-only vs. remote-Git modes, and credential storage/lifecycle.
+- **CLI compatibility:** supported CLI, install/auth prerequisite, generated template path, and known differences for Claude, Codex, Gemini, and OpenCode.
+- **Operating Ralph:** iteration limits, stopping safely, recovering from failures, reviewing/reverting commits, cost management, and how to escalate a story back to a human.
+
+Keep the current Usage Guide as a reference document, but split it into a fast-start guide and the operating/reference material above. Put full CLI commands and container/pnpm details behind clear progressive-disclosure sections.
+
+### 3. Repair and simplify existing copy
+
+Before changing visual design, complete a copy pass across `readme.md`, `docs/app/page.tsx`, `docs/app/how-it-works/page.tsx`, and `docs/app/usage-guide/page.tsx`:
+
+- Use direct, grammatical English and define Ralph in the first sentence.
+- Change absolute wording such as “fastest way” to evidence-based, scoped claims.
+- State that isolation and GitHub setup are optional wherever setup is introduced.
+- Describe the tool as scaffolded, inspectable scripts rather than autonomous magic.
+- Make test behavior conditional on project configuration; do not imply every repo has typecheck and tests.
+- Replace “all without you touching the keyboard” and the “clueless but persistent” joke with a review-first operating promise.
+- Ensure the same current facts appear in README, app source, package description, and generated site output.
+- Update package metadata: replace the generic description and expand keywords around autonomous coding workflow, AI coding CLI, task loop, Dev Container, and safe agent execution.
+
+### 4. Add proof before amplification
+
+Claims about unattended feature delivery need evidence. Produce and maintain:
+
+- A versioned demo repository for every supported CLI, with a fixed PRD and expected commit history.
+- Short captured terminal demos, plus a readable transcript for accessibility and indexing.
+- A “results and limits” page that reports scenarios rather than misleading aggregate benchmarks: story count, completion/review rate, retries, tests, tokens/cost where available, environment, and human intervention.
+- Three early user case studies or quotes only after permission, each documenting task fit and review process.
+- Screenshots of `prd.yaml`, `progress.txt`, and git history that visually connect the loop to its output.
+
+Do not publish unsupported claims such as “builds while AFK” without pairing them with the constraints: prepared requirements, agent capability, available credentials, test coverage, and human code review.
+
+## Acquisition and community plan
+
+### Channels
+
+Prioritize channels where developers already compare agent workflows:
+
+- GitHub README, Releases, Discussions, and issue templates.
+- Short technical posts showing a real completed backlog, including failures and recovery—not generic AI-agent thought leadership.
+- CLI-specific communities for Codex, Claude Code, Gemini CLI, and OpenCode; tailor examples rather than cross-posting identical copy.
+- Developer newsletters or communities after the demo and decision page are credible.
+
+Avoid paid acquisition until activation instrumentation shows that visitors understand task fit and complete the first run.
+
+### Content sequence
+
+1. “One-shot prompt or Ralph loop? A developer’s decision guide.”
+2. “From five acceptance criteria to five reviewable commits: a full Ralph run.”
+3. “Running autonomous coding safely: what a Dev Container does—and does not—protect.”
+4. One implementation post per supported CLI, based on verified differences.
+5. Postmortems of failed or partially successful runs to establish credibility.
+
+Every item should lead to a corresponding decision, demo, or fast-start page rather than a generic homepage.
+
+## Activation and measurement
+
+Instrument a privacy-respecting funnel or, if telemetry is not appropriate, use documented release/manual measurement:
+
+| Stage | Signal | Initial success criterion |
+| --- | --- | --- |
+| Interest | Hero CTA click to example or fast start | Visitors choose a path rather than immediately leave. |
+| Intent | `npx ralph-workflow` / package install | Track by npm downloads, segmented by release period. |
+| Setup | CLI completes scaffolding | Optional, anonymous opt-in event or demo-repo feedback. |
+| Activation | First passing, committed story | Primary product activation metric. |
+| Retention | Second real run or multiple stories completed | Indicates the loop, not novelty, delivered value. |
+| Trust | Safety-page completion, questions, and setup-path choice | Reveals whether isolation helps conversion or creates friction. |
+
+Set numeric targets only after a two-week baseline. Segment results by entry page, chosen CLI, local vs. container setup, new vs. returning users, and docs version. Do not infer product value from npm downloads alone.
+
+## 90-day implementation sequence
+
+### Phase 0 — Establish a truthful baseline (week 1)
+
+- Audit source docs, README, package metadata, CLI prompts, and deployed `docs/out/` for factual consistency.
+- Rebuild deployment artifacts or change the deployment process so generated output cannot become stale.
+- Run and record one end-to-end demo with the current release; log every prerequisite and failure point.
+- Interview 5–8 developers who use an AI coding CLI. Ask them to choose between a one-shot session and Ralph for concrete tasks, then test the proposed hero without explaining it.
+
+**Exit:** one canonical capability matrix, one verified demo run, and a ranked list of onboarding blockers.
+
+### Phase 1 — Clarify the offer (weeks 2–3)
+
+- Rewrite README and the home-page hero using the approved positioning and use-case boundaries.
+- Add fast local trial and safe unattended setup paths.
+- Publish the “Is Ralph right for this task?” and Safety Model pages.
+- Move deep setup details out of the first-reading path and repair copy quality.
+- Update title, meta description, Open Graph image, and npm metadata for the new promise.
+
+**Exit:** a first-time developer can answer what Ralph is, when to use it, how it differs from one-shot prompting, and how to start a low-risk trial in under two minutes of reading.
+
+### Phase 2 — Demonstrate the outcome (weeks 4–6)
+
+- Create the reproducible demo repository and two documented example runs.
+- Add a short terminal capture and an accessible transcript to the home page.
+- Publish CLI compatibility and operating/recovery guides.
+- Add issue/discussion templates for demo failures, use cases, and feature requests.
+- Add a final wizard confirmation that lists files and Git/GitHub actions about to occur; offer a dry-run preview where feasible.
+
+**Exit:** every headline claim has a linked, inspectable demonstration; a skeptical developer can evaluate a real run before configuring credentials.
+
+### Phase 3 — Learn from distribution (weeks 7–10)
+
+- Publish the decision-guide and full-run articles.
+- Share CLI-specific examples in relevant communities, disclose limitations, and invite feedback on task fit.
+- Collect opt-in qualitative feedback at the first-pass and first-failure points.
+- Test two hero variants: outcome-led versus safety-led for security-oriented referrers only.
+
+**Exit:** a documented channel/task-fit matrix and enough feedback to prioritize product onboarding changes.
+
+### Phase 4 — Convert proof into trust (weeks 11–13)
+
+- Publish user stories only where the user can review the exact claims.
+- Add a concise results-and-limits section based on repeatable scenarios.
+- Refine the setup wizard and docs based on the highest drop-off stage.
+- Establish a release checklist that requires docs, demo, compatibility matrix, and generated-site verification to be updated together.
+
+**Exit:** messaging, setup, proof, and release documentation stay consistent as the package evolves.
+
+## Ownership and release checklist
+
+Assign one accountable owner per release for messaging/docs, demo verification, CLI compatibility, and generated-site deployment. Before a release, verify:
+
+- The README, npm description, docs source, generated site, and CLI behavior describe the same version.
+- One demo per supported CLI still completes or its limitation is explicitly documented.
+- The home page includes task-fit guidance and does not overstate autonomy or security.
+- Links, CTA destinations, copy, and Open Graph metadata work in the deployed site.
+- A human has reviewed the runnable example and its resulting commits.
+
+## Risks and guardrails
+
+- **Overpromising autonomy:** Always pair outcome claims with task-fit boundaries and human review expectations.
+- **Security theater:** Document isolation’s limits, use least privilege, and never imply a Dev Container is an absolute security boundary.
+- **Setup friction:** Maintain the local trial path; measure whether container/PAT configuration is preventing activation.
+- **Stale proof:** Treat demos and generated documentation as release artifacts, not one-time marketing assets.
+- **Unsupported multi-CLI parity:** Market only verified behavior; present differences openly instead of flattening them into a generic compatibility claim.
+
+## Immediate next actions
+
+1. Confirm the canonical current CLI behavior and fix the `docs/out/` versus `docs/app/` mismatch.
+2. Produce one small, repeatable demo and record its terminal output and commit history.
+3. Rewrite the hero, README opening, and primary CTA around the prepared-backlog outcome.
+4. Publish the task-fit and safety-model pages before broader promotion.
+5. Interview the first 5–8 target developers and revise the plan using observed objections and activation friction.

--- a/docs/app/how-it-works/page.tsx
+++ b/docs/app/how-it-works/page.tsx
@@ -115,7 +115,7 @@ export default function HowItWorksPage() {
             <rect x="14" y="34" width="158" height="255" rx="8"
               fill="#1f0f0f" stroke="#ff6b6b" strokeOpacity="0.25" strokeWidth="1" />
             <text x="93" y="56" textAnchor="middle" fill="#ff6b6b" fillOpacity="0.6"
-              fontSize="9.5" fontFamily="monospace" fontWeight="bold">HOST ONLY</text>
+              fontSize="9.5" fontFamily="monospace" fontWeight="bold">NOT MOUNTED BY DEFAULT</text>
             {[
               '🔑  SSH keys',
               '🐙  Full GitHub session',
@@ -128,11 +128,11 @@ export default function HowItWorksPage() {
             {/* blocked label */}
             <rect x="28" y="162" width="130" height="22" rx="4" fill="#ff6b6b" fillOpacity="0.12" />
             <text x="93" y="177" textAnchor="middle" fill="#ff6b6b" fillOpacity="0.7"
-              fontSize="9" fontFamily="monospace" fontWeight="bold">✗  NOT accessible in container</text>
+              fontSize="9" fontFamily="monospace" fontWeight="bold">✗  NOT mounted by this setup</text>
 
             {/* PAT mount arrow (only thing that flows into container) */}
             <text x="93" y="218" textAnchor="middle" fill="#4ade80" fillOpacity="0.7"
-              fontSize="9" fontFamily="monospace">Fine-grained PAT</text>
+              fontSize="9" fontFamily="monospace">Optional fine-grained PAT</text>
             <text x="93" y="232" textAnchor="middle" fill="#4ade80" fillOpacity="0.5"
               fontSize="8" fontFamily="monospace">(mount from host)</text>
             <line x1="173" y1="225" x2="188" y2="225"
@@ -173,20 +173,20 @@ export default function HowItWorksPage() {
             <text x="302" y="107" textAnchor="middle" fill="#b39aff" fillOpacity="0.55"
               fontSize="8.5" fontFamily="monospace">reads/writes/runs commands freely</text>
             <text x="302" y="122" textAnchor="middle" fill="#b39aff" fillOpacity="0.4"
-              fontSize="8" fontFamily="monospace">inside container only</text>
+              fontSize="8" fontFamily="monospace">inside the selected environment</text>
 
             {/* Accessible resources box */}
             <rect x="205" y="152" width="195" height="130" rx="8"
               fill="#0f2a0f" stroke="#4ade80" strokeOpacity="0.4" strokeWidth="1" />
             <text x="302" y="172" textAnchor="middle" fill="#4ade80" fillOpacity="0.75"
-              fontSize="9.5" fontFamily="monospace" fontWeight="bold">Accessible to Ralph</text>
+              fontSize="9.5" fontFamily="monospace" fontWeight="bold">Explicitly available to Ralph</text>
 
             {/* PAT item */}
             <rect x="218" y="180" width="169" height="38" rx="5" fill="#0a1f0a" />
             <text x="302" y="196" textAnchor="middle" fill="#4ade80" fillOpacity="0.8"
               fontSize="9" fontFamily="monospace" fontWeight="bold">Fine-grained PAT</text>
             <text x="302" y="210" textAnchor="middle" fill="#4ade80" fillOpacity="0.55"
-              fontSize="8.5" fontFamily="monospace">scope: 1 repo • Contents: write</text>
+              fontSize="8.5" fontFamily="monospace">chosen repo • review permissions</text>
 
             {/* Repo item */}
             <rect x="218" y="224" width="169" height="38" rx="5" fill="#0a1f0a" />
@@ -221,18 +221,16 @@ export default function HowItWorksPage() {
         <div className="flex items-start gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm max-w-3xl mb-3">
           <span className="text-brand-purple font-bold flex-shrink-0">Fine-grained PAT</span>
           <span className="text-gray-400">
-            Even with full freedom inside the container, Ralph can only push to the single repository
-            the PAT is scoped to. Your host SSH keys, other GitHub repos, cloud accounts, and
-            org-wide access are never reachable.
+            A repository-scoped token limits GitHub access to the repository and permissions you configure.
+            It does not limit changes to the workspace or access to other resources you explicitly make available.
           </span>
         </div>
 
         <div className="flex items-start gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm max-w-3xl mb-3">
           <span className="text-brand-purple font-bold flex-shrink-0">Blast radius limitation</span>
           <span className="text-gray-400">
-            Even if Ralph goes off-script, it can only push to the single repository
-            the PAT is scoped to. No access to other repos, cloud accounts, or host
-            SSH keys.
+            Credential cleanup reduces accidental forwarding from VS Code. Review your mounts, network access,
+            available tools, and credentials before starting an unattended run.
           </span>
         </div>
 

--- a/docs/app/how-it-works/page.tsx
+++ b/docs/app/how-it-works/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'How It Works — Ralph Workflow',
+  title: 'How It Works',
 }
 
 const steps = [
@@ -59,31 +59,37 @@ const steps = [
 export default function HowItWorksPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 py-12">
-      <h1 className="text-3xl sm:text-4xl font-bold mb-6">How It Works</h1>
+      <h1 className="text-3xl sm:text-4xl font-bold mb-6">How Ralph Workflow works</h1>
+
+      <section className="max-w-3xl mb-12">
+        <h2 className="text-xl font-semibold mb-4 text-brand-purple">The execution loop</h2>
+        <p className="text-gray-400 text-sm leading-relaxed mb-4">
+          Ralph is an iterative execution pattern for a prepared backlog. Each pass selects one unfinished story,
+          uses the project context you keep in <code className="bg-white/10 text-brand-purple px-1 rounded">progress.txt</code>,
+          asks your chosen AI CLI to implement it, and records the outcome as a commit.
+        </p>
+        <p className="text-gray-400 text-sm leading-relaxed">
+          The loop is most useful when stories are small, acceptance criteria are testable, and you plan to review the
+          resulting commits. It is not a substitute for deciding what to build or accepting unreviewed changes.
+        </p>
+      </section>
 
       <section className="mb-16">
-        <h2 className="text-xl font-semibold mb-4 text-brand-purple">Ralph workflow idea</h2>
+        <h2 className="text-xl font-semibold mb-4 text-brand-purple">Optional isolated execution</h2>
         <p className="text-gray-400 text-sm leading-relaxed mb-4">
-          Ralph runs with <code className="bg-white/10 text-brand-purple px-1 rounded">--dangerously-skip-permissions</code> (or similar),
-          which means it has full access to whatever credentials are available inside
-          the container. The Dev Container setup limits blast radius by:
+          Ralph may run with <code className="bg-white/10 text-brand-purple px-1 rounded">--dangerously-skip-permissions</code> (or similar),
+          so it can read, write, and run commands inside the environment you choose. A VS Code Dev Container is optional;
+          it reduces exposure to common host credentials during unattended runs.
         </p>
-
-
         <p className="text-gray-400 text-sm leading-relaxed mb-6">
-          The Dev Container acts as a hard boundary. VS Code credential-forwarding is neutralized by a
+          The generated container setup clears common VS Code credential-forwarding variables with a
           <code className="bg-white/10 text-brand-purple px-1 mx-1 rounded">postStart</code>
-          hook before Ralph runs. The only credential Ralph ever sees is a fine-grained PAT you mount
-          from your host — scoped to one repo.
+          hook before Ralph runs. This reduces credential blast radius; it does not make unreviewed code, available
+          workspace files, or allowed network access inherently safe.
         </p>
-
-        <p className="text-gray-400 text-sm leading-relaxed mb-6">
-          VSCode dev container is well integrated with VSCode IDE which makes it convenient to quickly reopens project in container anytime.
-        </p>
-
-
         <p className="text-gray-400 text-sm leading-relaxed mb-4">
-          <p>ralph-workflow provide convenience for you to scaffolds those things up</p>
+          If Ralph needs to push, you can provide a fine-grained token scoped to the repository you choose. Review the
+          requested permissions and the generated configuration before using remote access.
         </p>
         <div className="overflow-x-auto mb-2">
           <svg

--- a/docs/app/is-ralph-right-for-me/page.tsx
+++ b/docs/app/is-ralph-right-for-me/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Is Ralph Right for Me?',
+  description:
+    'Decide when Ralph Workflow is a better fit than an interactive or one-shot AI coding session.',
+}
+
+const fitCases = [
+  'You have 3–15 small stories with concrete acceptance criteria.',
+  'Your project has checks the agent can run to validate each story.',
+  'You want a resumable sequence of small commits to review later.',
+]
+
+const antiFitCases = [
+  'You need a quick one-off fix or an exploratory conversation.',
+  'The product, design, or technical direction is still unclear.',
+  'The work is high-risk and requires continuous human judgment.',
+]
+
+export default function IsRalphRightForMePage() {
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-12">
+      <header className="max-w-3xl mb-12">
+        <p className="text-brand-purple text-sm font-semibold mb-3">DECISION GUIDE</p>
+        <h1 className="text-3xl sm:text-4xl font-bold mb-4">Is Ralph right for this task?</h1>
+        <p className="text-gray-400 text-lg leading-relaxed">
+          Ralph is an execution loop for a prepared, testable backlog. It complements your AI coding CLI;
+          it does not replace interactive engineering judgment.
+        </p>
+      </header>
+
+      <section className="grid md:grid-cols-2 gap-6 mb-14" aria-label="Task fit guidance">
+        <div className="border border-green-400/30 bg-green-400/5 rounded-lg p-6">
+          <h2 className="text-xl font-semibold text-green-300 mb-4">Use Ralph when</h2>
+          <ul className="space-y-3 text-sm text-gray-300">
+            {fitCases.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span aria-hidden="true" className="text-green-300">✓</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="border border-amber-300/30 bg-amber-300/5 rounded-lg p-6">
+          <h2 className="text-xl font-semibold text-amber-200 mb-4">Choose another workflow when</h2>
+          <ul className="space-y-3 text-sm text-gray-300">
+            {antiFitCases.map((item) => (
+              <li key={item} className="flex gap-3">
+                <span aria-hidden="true" className="text-amber-200">→</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="mb-14">
+        <h2 className="text-2xl font-semibold mb-5">One-shot session or Ralph loop?</h2>
+        <div className="overflow-x-auto border border-white/10 rounded-lg">
+          <table className="w-full min-w-[620px] text-left text-sm">
+            <thead className="bg-white/5 text-gray-200">
+              <tr>
+                <th scope="col" className="p-4 font-semibold">Choose based on</th>
+                <th scope="col" className="p-4 font-semibold">One-shot / interactive</th>
+                <th scope="col" className="p-4 font-semibold">Ralph Workflow</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/10 text-gray-400">
+              <tr>
+                <th scope="row" className="p-4 text-gray-200 font-medium">Best task shape</th>
+                <td className="p-4">One small change or an open-ended investigation.</td>
+                <td className="p-4">Several independent stories with explicit acceptance criteria.</td>
+              </tr>
+              <tr>
+                <th scope="row" className="p-4 text-gray-200 font-medium">Human involvement</th>
+                <td className="p-4">Frequent direction and real-time review.</td>
+                <td className="p-4">Prepare the backlog, then review tested commits at checkpoints.</td>
+              </tr>
+              <tr>
+                <th scope="row" className="p-4 text-gray-200 font-medium">Working state</th>
+                <td className="p-4">Conversation context is the main coordination mechanism.</td>
+                <td className="p-4"><code>prd.yaml</code> and <code>progress.txt</code> make work resumable.</td>
+              </tr>
+              <tr>
+                <th scope="row" className="p-4 text-gray-200 font-medium">Output</th>
+                <td className="p-4">A completed change to inspect now.</td>
+                <td className="p-4">A sequence of small commits with checks run per story.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="border border-brand-purple/40 bg-brand-purple/10 rounded-lg p-6 max-w-3xl">
+        <h2 className="text-xl font-semibold mb-2">Your review still matters</h2>
+        <p className="text-gray-300 text-sm leading-relaxed mb-4">
+          Treat Ralph&apos;s commits as work submitted for review. Confirm the acceptance criteria, inspect the diff,
+          run the checks you trust, and merge only what you accept.
+        </p>
+        <div className="flex flex-wrap gap-4 text-sm">
+          <Link href="/how-it-works" className="text-brand-purple hover:underline">See the loop →</Link>
+          <Link href="/safety-and-control" className="text-brand-purple hover:underline">Review safety controls →</Link>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -4,8 +4,12 @@ import Navbar from '../components/Navbar'
 import Footer from '../components/Footer'
 
 export const metadata: Metadata = {
-  title: 'Ralph Workflow',
-  description: 'Documentation for ralph-workflow',
+  title: {
+    default: 'Ralph Workflow',
+    template: '%s | Ralph Workflow',
+  },
+  description:
+    'Turn a prepared feature backlog into tested, reviewable commits with your AI coding CLI.',
 }
 
 export default function RootLayout({

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1,151 +1,137 @@
 import Link from 'next/link'
 
-const features = [
+const proofArtifacts = [
+  'Starting commit and the complete PRD',
+  'Command and explicit iteration cap',
+  'Terminal record of the run and any retries',
+  'Commit history and final diff',
+  'Checks run for each completed story',
+  'Human review decisions before merge',
+]
+
+const loopSteps = [
   {
-    title: 'Scaffold ralph script fast',
-    description:
-      'Works with Claude, Codex, Gemini, and Opencode. Pick your AI CLI during setup; ralph.sh pipes the same prompt loop to whichever you choose.',
+    title: 'Prepare small stories',
+    description: 'Describe testable acceptance criteria in prd.yaml before the loop starts.',
   },
   {
-    title: 'Dev Container Templates',
-    description:
-      'Leveraging VSCode Dev container to provide isolation for ralph loop. Scaffolded templates pre-configure isolation, dependencies, and auto-install RTK with rtk init already run for your chosen CLI so token-reduction kicks in on first boot. For Claude, opt in to the Caveman debug plugin and the awesome-claude-code-subagents collection.',
+    title: 'Run the loop',
+    description: 'Ralph selects the next unfinished story, carries forward project context, and runs your AI CLI.',
   },
   {
-    title: 'Credential Isolation',
-    description:
-      'ralph-workflow provides convenience to passing github PAT token if ralph needs it, perform credential cleaning within container programmatically. GitHub setup is now independent from the Dev Container — pick either, both, or neither.',
-  },
-  {
-    title: 'Ralph Task Loop',
-    description:
-      'Define stories in prd.yaml, run ralph.sh, and watch the agent implement, test, commit, and mark each story done — all without you touching the keyboard.',
+    title: 'Review commits',
+    description: 'Inspect the tested changes and keep or reject them as you would any other submitted work.',
   },
 ]
 
 export default function Home() {
   return (
     <>
-      {/* Hero */}
       <section className="py-20 px-4 border-b border-white/10">
         <div className="max-w-5xl mx-auto text-center">
-          <h1 className="text-4xl sm:text-5xl font-bold mb-4 tracking-tight">
-            🔄 ralph-workflow
+          <p className="text-brand-purple text-sm font-semibold mb-4">AUTONOMOUS FEATURE EXECUTION FOR YOUR AI CLI</p>
+          <h1 className="text-4xl sm:text-5xl font-bold mb-5 tracking-tight max-w-4xl mx-auto">
+            Ship a prepared feature backlog while you&apos;re away.
           </h1>
-          <p className="text-lg sm:text-xl text-gray-400 mb-8 max-w-2xl mx-auto">
-            Scaffold everything you need to run Ralph safely inside a VS Code Dev Container
-            with isolated GitHub credentials and an autonomous AI coding loop.
+          <p className="text-lg sm:text-xl text-gray-400 mb-8 max-w-3xl mx-auto leading-relaxed">
+            Ralph Workflow drives Claude, Codex, Gemini, or OpenCode through small, testable stories—preserving
+            context, running checks, and creating reviewable commits. It is built for a bounded backlog, not a
+            replacement for engineering judgment.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link
-              href="/usage-guide"
+              href="/is-ralph-right-for-me"
               className="inline-block bg-brand-purple text-brand-bg font-semibold px-6 py-3 rounded hover:bg-brand-purple-light transition-colors"
             >
-              Get Started
+              Is Ralph right for me?
             </Link>
-            <a
-              href="https://github.com/rickvian/ralph-workflow"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/how-it-works"
               className="inline-block border border-white/20 text-gray-200 font-semibold px-6 py-3 rounded hover:border-brand-purple hover:text-brand-purple transition-colors"
             >
-              GitHub ↗
-            </a>
+              See the loop in action
+            </Link>
           </div>
         </div>
       </section>
 
-      {/* Features */}
       <section className="py-16 px-4 border-b border-white/10">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold text-center mb-10">
-            Why ralph-workflow?
-          </h2>
-          <div className="grid sm:grid-cols-2 gap-6">
-            {features.map((f) => (
-              <div key={f.title} className="bg-white/5 rounded-lg border border-white/10 p-6">
-                <h3 className="text-lg font-semibold mb-2 text-brand-purple">{f.title}</h3>
-                <p className="text-gray-400 text-sm leading-relaxed">{f.description}</p>
-              </div>
+          <div className="max-w-3xl mb-8">
+            <p className="text-brand-purple text-sm font-semibold mb-3">PROOF, NOT PROMISES</p>
+            <h2 className="text-2xl sm:text-3xl font-bold mb-3">Know what to inspect in a real Ralph run.</h2>
+            <p className="text-gray-400 leading-relaxed">
+              A credible autonomous run is reproducible and reviewable. Before relying on one, ask for these
+              artifacts—not a polished claim that an agent “built an app.”
+            </p>
+          </div>
+          <ul className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4" aria-label="Proof artifacts">
+            {proofArtifacts.map((artifact) => (
+              <li key={artifact} className="border border-white/10 bg-white/5 rounded-lg p-4 text-sm text-gray-300 flex gap-3">
+                <span aria-hidden="true" className="text-brand-purple">✓</span>
+                <span>{artifact}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="py-16 px-4 border-b border-white/10">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-2xl sm:text-3xl font-bold text-center mb-10">A loop with clear checkpoints</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            {loopSteps.map((step, index) => (
+              <article key={step.title} className="border border-white/10 bg-white/5 rounded-lg p-6">
+                <p className="font-mono text-brand-purple text-sm mb-4">0{index + 1}</p>
+                <h3 className="text-lg font-semibold mb-2">{step.title}</h3>
+                <p className="text-gray-400 text-sm leading-relaxed">{step.description}</p>
+              </article>
             ))}
           </div>
-
-          <div className="flex justify-center mt-10">
-            <Link href="/how-it-works" className="text-brand-purple hover:underline">
-              More about how it works ➡️
-            </Link>
+          <div className="text-center mt-8">
+            <Link href="/how-it-works" className="text-brand-purple hover:underline">Explore the Ralph loop →</Link>
           </div>
         </div>
       </section>
 
-      {/* Quick Start */}
       <section className="py-16 px-4 border-b border-white/10">
-        <div className="max-w-5xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold text-center mb-8">
-            Quick Start
-          </h2>
-          <pre className="bg-black/40 border border-white/10 text-green-400 rounded-lg p-6 overflow-x-auto text-sm leading-relaxed">
-            <code>{`$ npx ralph-workflow
-
-? Which AI coding CLI? (claude/codex/gemini/opencode) claude
-? Set up VS Code Dev Container for isolation? (Y/n) Y
-? Set up GitHub repository with isolated PAT? (Y/n) Y
-? Install Caveman debugging plugin? (y/N) n
-? Install curated awesome-claude-code-subagents collection? (y/N) n
-? Choose a Dev Container template: Node 20
-  → Open https://github.com/settings/personal-access-tokens/new
-  → Select only this repository, grant Contents: write
-? Paste your PAT: **********************************
-
-✓ .devcontainer/devcontainer.json written
-✓ RTK + rtk init queued in postCreateCommand
-✓ scripts/ralph/ scaffolded
-✓ PAT stored at .ralph/token (gitignored, mode 0600)
-
-Reopen this folder in the Dev Container to start.`}</code>
-          </pre>
-          <p className="text-center mt-6 text-gray-400 text-sm">
-            Then edit <code className="bg-white/10 text-brand-purple px-1 rounded">scripts/ralph/prd.yaml</code>,
-            run{' '}
-            <code className="bg-white/10 text-brand-purple px-1 rounded">./scripts/ralph/ralph.sh 25</code>,
-            and let Ralph do the rest, safely in isolated environment{' '}
-            <Link href="/usage-guide" className="text-brand-purple hover:underline">
-              Full guide →
+        <div className="max-w-5xl mx-auto grid lg:grid-cols-[1.25fr_1fr] gap-10 items-start">
+          <div>
+            <p className="text-brand-purple text-sm font-semibold mb-3">START WITH TASK FIT</p>
+            <h2 className="text-2xl sm:text-3xl font-bold mb-4">Ralph is not the right tool for every task.</h2>
+            <p className="text-gray-400 leading-relaxed mb-5">
+              Use an interactive session for a one-off change or unclear direction. Use Ralph when you have several
+              independently verifiable stories and want a resumable sequence of commits to review.
+            </p>
+            <Link href="/is-ralph-right-for-me" className="text-brand-purple hover:underline">
+              Compare Ralph with a one-shot session →
             </Link>
-          </p>
+          </div>
+          <aside className="border border-brand-purple/40 bg-brand-purple/10 rounded-lg p-6">
+            <h3 className="text-lg font-semibold mb-3">Add isolation when you need it</h3>
+            <p className="text-gray-300 text-sm leading-relaxed mb-4">
+              Start locally to evaluate the loop. Add a Dev Container and a scoped GitHub token only when your
+              unattended run needs that access.
+            </p>
+            <Link href="/safety-and-control" className="text-brand-purple hover:underline text-sm">
+              Review safety and control options →
+            </Link>
+          </aside>
         </div>
       </section>
 
-      {/* Contributors */}
       <section className="py-16 px-4">
-        <div className="max-w-5xl mx-auto text-center">
-          <h2 className="text-2xl sm:text-3xl font-bold mb-4">Contributors</h2>
-          <p className="text-gray-400 mb-8 max-w-xl mx-auto text-sm">
-            Built by the community. Every bug report, PR, and idea counts.
+        <div className="max-w-3xl mx-auto text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold mb-4">Ready to prepare a backlog?</h2>
+          <p className="text-gray-400 mb-7">
+            Start with a small, local run. Keep stories testable, cap iterations, and review every commit before merge.
           </p>
-          <div className="flex flex-wrap justify-center gap-4 mb-10">
-            <a
-              href="https://rickvianaldi.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 bg-white/5 border border-white/10 rounded-lg px-4 py-2 hover:border-brand-purple transition-colors text-sm"
-            >
-              <img
-                src="https://github.com/rickvian.png"
-                alt="rickvian"
-                className="w-6 h-6 rounded-full"
-              />
-              <span className="text-gray-200">Rickvian Aldi</span>
-            </a>
-          </div>
-          <a
-            href="https://github.com/rickvian/ralph-workflow/blob/main/CONTRIBUTING.md"
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            href="/usage-guide"
             className="inline-block border border-brand-purple text-brand-purple font-semibold px-6 py-3 rounded hover:bg-brand-purple hover:text-brand-bg transition-colors"
           >
-            Become a contributor ↗
-          </a>
+            Read the setup guide →
+          </Link>
         </div>
       </section>
     </>

--- a/docs/app/safety-and-control/page.tsx
+++ b/docs/app/safety-and-control/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Safety & Control',
+  description:
+    'Understand local, isolated, and remote-Git Ralph Workflow setups before running an autonomous coding loop.',
+}
+
+const modes = [
+  {
+    title: 'Local-only trial',
+    description: 'Scaffold Ralph and work with local Git. Use this to evaluate the loop without remote repository access.',
+  },
+  {
+    title: 'Isolated container',
+    description: 'Run in a VS Code Dev Container that clears common forwarded credentials before the agent starts.',
+  },
+  {
+    title: 'Scoped remote access',
+    description: 'Add a repository-scoped GitHub token only when the agent needs to push. Review the requested permissions before creating it.',
+  },
+]
+
+export default function SafetyAndControlPage() {
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-12">
+      <header className="max-w-3xl mb-12">
+        <p className="text-brand-purple text-sm font-semibold mb-3">SAFETY & CONTROL</p>
+        <h1 className="text-3xl sm:text-4xl font-bold mb-4">Choose the access Ralph needs—and no more.</h1>
+        <p className="text-gray-400 text-lg leading-relaxed">
+          Ralph runs an AI coding CLI with broad permission inside its chosen environment. The workflow gives you
+          explicit setup choices; it does not make autonomous code execution risk-free.
+        </p>
+      </header>
+
+      <section className="mb-14">
+        <h2 className="text-2xl font-semibold mb-5">Start with the smallest mode that works</h2>
+        <div className="grid md:grid-cols-3 gap-5">
+          {modes.map((mode) => (
+            <article key={mode.title} className="border border-white/10 bg-white/5 rounded-lg p-5">
+              <h3 className="text-lg font-semibold text-brand-purple mb-2">{mode.title}</h3>
+              <p className="text-gray-400 text-sm leading-relaxed">{mode.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid md:grid-cols-2 gap-6 mb-14">
+        <div>
+          <h2 className="text-2xl font-semibold mb-4">What isolation helps with</h2>
+          <ul className="list-disc pl-5 space-y-2 text-gray-400 text-sm leading-relaxed">
+            <li>Reduces accidental exposure of common VS Code-forwarded credentials.</li>
+            <li>Lets you provide a repository-scoped token instead of your normal host session.</li>
+            <li>Separates project-specific container configuration from your daily development environment.</li>
+          </ul>
+        </div>
+        <div>
+          <h2 className="text-2xl font-semibold mb-4">What isolation does not guarantee</h2>
+          <ul className="list-disc pl-5 space-y-2 text-gray-400 text-sm leading-relaxed">
+            <li>Does not make unreviewed code, dependencies, or network access inherently safe.</li>
+            <li>Does not prevent the agent from changing files or consuming resources available in its workspace.</li>
+            <li>Does not replace least-privilege credentials, iteration limits, or human review.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="border border-white/10 bg-white/5 rounded-lg p-6 max-w-3xl">
+        <h2 className="text-2xl font-semibold mb-4">Keep the loop under review</h2>
+        <ol className="list-decimal pl-5 space-y-2 text-gray-400 text-sm leading-relaxed">
+          <li>Keep stories small and acceptance criteria testable.</li>
+          <li>Set an explicit iteration cap when running <code>ralph.sh</code>.</li>
+          <li>Inspect the branch and commit history before merging or pushing further changes.</li>
+          <li>Stop the loop and return to an interactive session when the task becomes ambiguous.</li>
+        </ol>
+      </section>
+
+      <p className="mt-8 text-sm text-gray-400">
+        Need the setup details? <Link href="/usage-guide" className="text-brand-purple hover:underline">Read the usage guide →</Link>
+      </p>
+    </div>
+  )
+}

--- a/docs/components/Navbar.tsx
+++ b/docs/components/Navbar.tsx
@@ -5,8 +5,10 @@ import { useState } from 'react'
 
 const navLinks = [
   { href: '/', label: 'Home' },
+  { href: '/is-ralph-right-for-me', label: 'Is Ralph for me?' },
   { href: '/usage-guide', label: 'Usage Guide' },
-  { href: '/how-it-works', label: 'How It Works' }
+  { href: '/how-it-works', label: 'How It Works' },
+  { href: '/safety-and-control', label: 'Safety & Control' },
 ]
 
 export default function Navbar() {

--- a/docs/plans/marketing-proof.md
+++ b/docs/plans/marketing-proof.md
@@ -1,0 +1,97 @@
+# Marketing Proof Plan
+
+Status: Implemented
+
+## Outcome
+
+Make Ralph Workflow’s documentation answer three questions immediately: **what outcome it delivers**, **when it beats a one-shot coding session**, and **how developers retain control**.
+
+## Scope
+
+**Include**
+
+- **Reframe** the home page around prepared backlog → tested, reviewable commits.
+- **Add** task-fit and safety/control pages.
+- **Align** navigation, metadata, README, and targeted How It Works copy.
+- **Describe** trustworthy proof artifacts without inventing performance claims.
+
+**Exclude**
+
+- **Change** CLI, authentication, PAT permissions, containers, or GitHub behavior.
+- **Create** a demo repository, video, telemetry, benchmarks, or deployment changes.
+- **Rewrite** the complete usage guide or redesign the visual system.
+
+## Acceptance Criteria
+
+- [ ] **Explain** Ralph’s outcome, intended audience, and task boundary in the home-page first viewport.
+- [ ] **Provide** a dedicated comparison between Ralph and one-shot work, including clear anti-fit cases and human review expectations.
+- [ ] **Present** a proof framework that names inspectable run artifacts and contains no unverified data.
+- [ ] **Qualify** isolation as credential-blast-radius reduction and distinguish local, container, and remote-Git modes.
+- [ ] **Keep** navigation, README, titles, and page descriptions consistent with the new message.
+- [ ] **Pass** the docs build and browser checks for the changed routes at mobile and desktop widths.
+
+## Current Gap
+
+- **Lead** with setup mechanics today: the home page prioritizes scaffolding, Dev Containers, credentials, and a long install transcript.
+- **Hide** task fit today: visitors cannot quickly see when Ralph is preferable to a normal interactive agent session.
+- **Fragment** trust today: safety language is overly absolute, while proof, task boundaries, and review guidance are absent from the first-reading path.
+
+## Milestones
+
+| Milestone | Deliverable | Completion signal |
+| --- | --- | --- |
+| **1. Create decision paths** | Add task-fit and safety/control routes; expose them in navigation. | Readers can choose an appropriate workflow before setup. |
+| **2. Reframe first impression** | Rewrite the home hero and early sections around outcome, proof, fit, and optional isolation. | The primary CTA leads to evaluation rather than setup. |
+| **3. Align entry points** | Update metadata, README opening, and How It Works introduction. | Every entry point uses the same scoped promise. |
+| **4. Verify experience** | Build the docs and exercise navigation and layouts in a browser. | Changed routes work without console errors at 320px and desktop. |
+
+## Implementation Design
+
+**Guide** first-time readers through this sequence:
+
+```mermaid
+flowchart LR
+    A[Outcome and proof] --> B{Bounded, testable backlog?}
+    B -->|Yes| C[Task fit and quick start]
+    B -->|No| D[Interactive or one-shot session]
+    C --> E[Local or isolated execution]
+    E --> F[Review tested commits]
+```
+
+**Keep** the current dark visual system and static Next.js architecture. **Separate** evaluation content from detailed setup by adding two focused pages:
+
+- **Task fit:** Compare Ralph with a one-shot session, show fit/anti-fit, and set review expectations.
+- **Safety and control:** Explain setup modes, iteration limits, inspectable artifacts, and scoped isolation claims.
+
+**Frame** proof as a checklist of artifacts to inspect: starting commit, PRD, command and iteration cap, terminal record, git log, test results, and human review. **Avoid** linking to or implying a demo that does not exist.
+
+## File Map
+
+| File | Change |
+| --- | --- |
+| `docs/app/page.tsx` | **Rewrite** hero and early sections around outcome, proof, task fit, and optional isolation. |
+| `docs/app/is-ralph-right-for-me/page.tsx` | **Add** one-shot comparison and task-fit guidance. |
+| `docs/app/safety-and-control/page.tsx` | **Add** scoped safety and operational-control guidance. |
+| `docs/components/Navbar.tsx` | **Expose** both decision resources on desktop and mobile. |
+| `docs/app/layout.tsx` | **Improve** default metadata. |
+| `docs/app/how-it-works/page.tsx` | **Lead** with loop mechanics and qualify isolation copy. |
+| `readme.md` | **Align** opening copy and documentation links. |
+
+## Verification
+
+- **Run** `npm test` and `npm run docs:build`.
+- **Check** Home, Usage Guide, How It Works, Task Fit, and Safety & Control through the site navigation.
+- **Inspect** changed pages at 320px and desktop width for layout, keyboard access, links, and console errors.
+- **Review** the final diff for unsupported claims, accessibility regressions, and copy consistency.
+
+## Risks, Dependencies, and Assumptions
+
+- **Avoid** overpromising agent reliability by pairing the promise with task-fit boundaries and human review.
+- **Preserve** the existing navigation focus with concise labels and no new dependencies.
+- **Treat** checked-in generated `docs/out/` artifacts as build output; rebuild rather than edit them manually, then confirm whether repository policy requires committing them.
+- **Assume** no verified public demo repository exists; present a proof framework only.
+- **Assume** Claude, Codex, Gemini, and OpenCode remain supported; avoid implying identical behavior across providers.
+
+## Approval Needed
+
+**Record** browser automation as follow-up: `agent-browser` is unavailable in this workspace, so interactive browser verification could not run. Static route rendering, type checking, package tests, and production build verification completed.

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
-Ralph workflow provides fastest way to scaffolds isolated ralph project.
-Provides everything you need to run Ralph safely inside a VS Code Dev Container with isolated GitHub credentials.
+Turn a prepared feature backlog into tested, reviewable commits with your existing AI coding CLI.
+
+`ralph-workflow` scaffolds Ralph's iterative execution loop for Claude, Codex, Gemini, or OpenCode. Use it for several small, independently verifiable stories—not for one-off changes, unclear direction, or work that needs continuous human judgment.
 
 [Read the documentation](https://rickvian.github.io/ralph-workflow).
 
@@ -8,8 +9,7 @@ Provides everything you need to run Ralph safely inside a VS Code Dev Container 
 
 🔄 Ralph is an autonomous AI coding agent loop based on https://ghuntley.com/ralph/
 
-This is really suitable for exploratory projects
-provide it with directions and requirements, leave it AFK, and it develops for you.
+Ralph repeatedly selects the next unfinished story, carries forward project context, asks your chosen AI CLI to implement it, runs the configured checks, and records a commit. You prepare the backlog; Ralph produces work for you to inspect and accept.
 
 
 ```bash
@@ -18,13 +18,21 @@ npx ralph-workflow
 
 ---
 
-## Why isolation matters
+## When to use Ralph Workflow
+
+Use Ralph Workflow when you have a bounded backlog with concrete acceptance criteria and checks the agent can run. Choose an interactive or one-shot AI coding session when the task is small, ambiguous, high-risk, or requires frequent product and design decisions.
+
+Before relying on a run, inspect the starting commit, PRD, iteration cap, terminal output, git history, checks, and final review decisions. Ralph's commits are submitted work—not an automatic merge decision.
+
+## Optional isolation
 
 Ralph runs with `--dangerously-skip-permissions`. Without isolation, it operates with your full host credentials — meaning it could access every private repo, cloud account, or service your machine can reach. The Dev Container setup prevents this by:
 
 - Blanking out VS Code's credential-forwarding environment variables (`GIT_ASKPASS`, `VSCODE_GIT_*`, `SSH_AUTH_SOCK`, `GITHUB_TOKEN`, etc.)
 - Disabling VS Code's git auth helpers inside the container
 - Mounting only a single-repo fine-grained PAT, not your host keychain
+
+This reduces credential blast radius; it does not make autonomous code execution inherently safe. Start locally if you only want to evaluate the loop, and add a container or remote GitHub access only when needed.
 
 
 ## What it does


### PR DESCRIPTION
## What changed

- Reframed the documentation home page around a prepared backlog becoming tested, reviewable commits.
- Added task-fit and safety/control pages, plus navigation and metadata updates.
- Aligned README and How It Works copy with scoped, review-first safety language.
- Added the marketing strategy and concise implementation plan.

## Why

The previous first-reading path led with containers and credentials before explaining when Ralph is useful or how developers should evaluate its output.

## Validation

- `npm test` — 30 tests passed
- `cd docs && npm run typecheck`
- `cd docs && npm run build`
- Local route smoke checks for Home, Usage Guide, How It Works, Task Fit, and Safety & Control

## Follow-up

Interactive browser automation could not run because `agent-browser` is unavailable in this workspace. The production build and local route checks passed.